### PR TITLE
Use Travis' multiple Python version feature via tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: python
-python: 3.4
+python:
+  - "3.3"
+  - "3.4"
+  - "3.5"
 install:
-  - pip install tox
-  - pip install python-coveralls
+  - pip install tox tox-travis python-coveralls
 script: tox
-after_success:
-  - coveralls
+after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
   - "3.4"
   - "3.5"
 install:
-  - pip install tox tox-travis python-coveralls
+  - pip install tox tox-travis coveralls
 script: tox
 after_success: coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,8 @@ envlist=py33, py34, py35
 deps=-rrequirements/development.txt
 commands=py.test --cov hug tests
     coverage report
+
+[tox:travis]
+3.3 = py33
+3.4 = py34
+3.5 = py35


### PR DESCRIPTION
This uses Travis functionality to split the build into multiple jobs, one job for every Python version.