### PR TITLE
Make build faster by removing unnecessary tox dependencies

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,6 @@
+-r common.txt
+pytest==2.8.2
+pytest-cov==2.2.0
+isort==4.2.2
+wheel==0.26.0
+python-coveralls==2.5.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=py33, py34, py35
 
 [testenv]
-deps=-rrequirements/development.txt
+deps=-rrequirements/build.txt
 commands=py.test --cov hug tests
     coverage report
 


### PR DESCRIPTION
Before:

    tox -e py35  28.94s user 2.65s system 72% cpu 43.869 total

After:

    tox -e py35  8.60s user 1.32s system 62% cpu 15.912 total