### PR TITLE
Allow serialization of decimal.Decimal

### DIFF
--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -23,6 +23,7 @@ import base64
 import json as json_converter
 import mimetypes
 import os
+from decimal import Decimal
 from datetime import date, datetime
 from io import BytesIO
 
@@ -49,6 +50,8 @@ def _json_converter(item):
             return base64.b64encode(item)
     elif hasattr(item, '__iter__'):
         return list(item)
+    elif isinstance(item, Decimal):
+        return str(item)
 
     raise TypeError("Type not serializable")
 

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -22,6 +22,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 from io import BytesIO
 from collections import namedtuple
 from datetime import datetime
+from decimal import Decimal
 
 import pytest
 
@@ -68,6 +69,9 @@ def test_json():
 
     data = (number for number in range(1, 4))
     assert hug.input_format.json(BytesIO(hug.output_format.json(data))) == [1, 2, 3]
+
+    data = [Decimal(1.5), Decimal("155.23"), Decimal("1234.25")]
+    assert hug.input_format.json(BytesIO(hug.output_format.json(data))) == ["1.5", "155.23", "1234.25"]
 
     with open('README.md', 'rb') as json_file:
         assert hasattr(hug.output_format.json(json_file), 'read')


### PR DESCRIPTION
Allows serialization of python standard library `decimal.Decimal` objects using the default json-formatter. Works well with the previously introduced Marshmallow support and its DecimalField :-)