### PR TITLE
Fixes issue #123: add support for Content-Type parameter charset=ENCODING

### DIFF
--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -25,15 +25,15 @@ from hug.format import content_type, underscore
 
 
 @content_type('text/plain')
-def text(body):
+def text(body, encoding='utf-8'):
     '''Takes plain text data'''
-    return body.read().decode('utf8')
+    return body.read().decode(encoding)
 
 
 @content_type('application/json')
-def json(body):
+def json(body, encoding='utf-8'):
     '''Takes JSON formatted data, converting it into native Python objects'''
-    return json_converter.loads(text(body))
+    return json_converter.loads(text(body, encoding=encoding))
 
 
 def _underscore_dict(dictionary):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -530,6 +530,17 @@ def test_input_format():
     api.__hug__.set_input_format('application/json', old_format)
 
 
+def test_content_type_with_parameter():
+    '''Test a Content-Type with parameter as `application/json charset=UTF-8`
+    as described in https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7'''
+    @hug.get()
+    def demo(body):
+        return body
+
+    assert hug.test.get(api, 'demo', body={}, headers={'Content-Type': 'application/json'}).data == {}
+    assert hug.test.get(api, 'demo', body={}, headers={'Content-Type': 'application/json; charset=UTF-8'}).data == {}
+
+
 def test_middleware():
     '''Test to ensure the basic concept of a middleware works as expected'''
     @hug.request_middleware()


### PR DESCRIPTION
Working but perhaps some custom input formatter will need to be updated, as in `test_decorators.py:test_input_format()` to support the second argument.

Is it OK?