### PR TITLE
Feature/improve sockets

### DIFF
--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -170,15 +170,9 @@ class TestSocket(object):
         assert self.service.connection.sockopts == {(self.socket.SOL_SOCKET, self.socket.SO_KEEPALIVE, 1),
                                                        (self.socket.SOL_SOCKET, self.socket.SO_REUSEADDR, 1)}
 
-    def test_request_with_headers(self):
-        """Test to ensure requesting data with content-type specified works as expected"""
-        assert ' '.join(self.service.request(query='GET / HTTP/1.0\r\n\r\n', timeout=120,
-                                              headers={'content-type': 'text/html'}
-                                              ).data.split()[:2]) == 'HTTP/1.1 200'
-
     def test_request(self):
         """Test to ensure requesting data from a socket service works as expected"""
-        assert b' '.join(self.service.request(query='GET / HTTP/1.0\r\n\r\n').data.split()[:2]) == b'HTTP/1.1 200'
+        assert b' '.join(self.service.request(query='GET / HTTP/1.0\r\n\r\n', timeout=30).data.read().split()[:2]) == b'HTTP/1.1 200'
 
 
 

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -155,6 +155,10 @@ class TestSocket(object):
         assert self.service.connection.proto == 'tcp'
         assert self.service.connection.sockopts == set()
 
+    def test_settimeout(self):
+        self.service.settimeout(60)
+        assert self.service.timeout == 60
+
     def test_connection_sockopts_unit(self):
         self.service.connection.sockopts.clear()
         self.service.setsockopt(self.socket.SOL_SOCKET, self.socket.SO_KEEPALIVE, 1)


### PR DESCRIPTION
This pull requests makes changes to timeout behavior, data format, and removal of unnecessary features. Tests updated, with 100% coverage.

Timeout changes are as follows:
On Socket object creation, when `timeout` is set, it will be the default timeout value for all calls to `request`, but can be changed with the `settimeout` method. Also, when `request` is called with a timeout, it is only reflected that one time while `request` is sending the data, when the socket is re-connected, it defaults back the default timeout.

Data format changes:
I removed `rstrip()` on the data that is sent back to the socket, we should not guess what the user wants to do with the output, so, in this case we don't do anything with newlines.

Header changes:
I removed the headers arg in the `__init__`, content-type was the only key we were checking, and in the context of sockets, content-type is irrelevant.

