### PR TITLE
Feature/timeouts and examples

### DIFF
--- a/examples/use_socket.py
+++ b/examples/use_socket.py
@@ -1,0 +1,33 @@
+"""A basic example of using hug.use.Socket to return data from raw sockets"""
+import hug
+import socket
+import struct
+import time
+
+
+http_socket = hug.use.Socket(connect_to=('www.google.com', 80), proto='tcp', pool=4, timeout=10.0)
+ntp_service = hug.use.Socket(connect_to=('127.0.0.1', 123), proto='udp', pool=4, timeout=10.0)
+
+
+EPOCH_START = 2208988800
+@hug.get()
+def get_time():
+    """Get time from a locally running NTP server"""
+
+    time_request = '\x1b' + 47 * '\0'
+    now = struct.unpack("!12I", ntp_service.request(time_request, timeout=5.0).data.read())[10]
+    return time.ctime(now - EPOCH_START)
+
+
+@hug.get()
+def reverse_http_proxy(length:int=100):
+    """Simple reverse http proxy function that returns data/html from another http server (via sockets)
+    only drawback is the peername is static, and currently does not support being changed.
+    Example: curl localhost:8000/reverse_http_proxy?length=400"""
+
+    http_request = """
+GET / HTTP/1.0\r\n\r\n
+Host: www.google.com\r\n\r\n
+\r\n\r\n
+"""
+    return http_socket.request(http_request, timeout=5.0).data.read()[0:length]

--- a/hug/use.py
+++ b/hug/use.py
@@ -231,13 +231,16 @@ class Socket(Service):
         data, address = _socket.recvfrom(buffer_size)
         return BytesIO(data)
 
-    def request(self, message, timeout=None, *args, **kwargs):
+    def request(self, message, timeout=False, *args, **kwargs):
         """Populate connection pool, send message, return BytesIO, and cleanup"""
         if not self.connection_pool.full():
             self.connection_pool.put(self._register_socket())
 
         _socket = self.connection_pool.get()
-        _socket.settimeout(timeout)
+
+        # setting timeout to None enables the socket to block.
+        if timeout or timeout is None:
+            _socket.settimeout(timeout)
 
         data = self.send_and_receive(_socket, message, *args, **kwargs)
 


### PR DESCRIPTION
Fix a bug in timeout logic, socket timeouts are kinda weird in that if you do `settimeout` on a socket with `None`, it will actually force the socket to block and never timeout, since I had `None` be the default value for `timeout` in the `request` function, this was causing bad sockets to never timeout.

And, add example code for using `hug.use.Socket`.