### PR TITLE
Add more Socket type attributes and enforce tuple for inet

### DIFF
--- a/hug/use.py
+++ b/hug/use.py
@@ -169,10 +169,13 @@ class Socket(Service):
     }
     streams = ('tcp', 'unix_stream')
     datagrams = ('udp', 'unix_dgram')
+    inet = ('tcp', 'udp')
+    unix = ('unix_stream', 'unix_dgram')
 
     def __init__(self, connect_to, proto, version=None,
                  headers=empty.dict, timeout=None, pool=0, raise_on=(500, ), **kwargs):
         super().__init__(timeout=timeout, raise_on=raise_on, version=version, **kwargs)
+        connect_to = tuple(connect_to) if proto in Socket.inet else connect_to
         self.timeout = timeout
         self.connection = Socket.Connection(connect_to, proto, set())
         self.connection_pool = Queue(maxsize=pool if pool else 1)


### PR DESCRIPTION
While using the socket interface for other projects, I'm noticing that it would be _super_ useful if we could just have the initialization step auto cast `inet` sockets into tuples, else; return strings (i.e in the case of `AF_UNIX` sockets).

To achieve this, I'm also adding 2 class level attributes, `inet` and `unix` to do protocol checking on initialization of `use.Socket`.