### PR TITLE
Make tests independent from root directory

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -19,6 +19,7 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
+import os
 import sys
 from unittest import mock
 
@@ -30,6 +31,8 @@ import hug
 
 api = hug.API(__name__)
 module = sys.modules[__name__]
+test_directory = os.path.dirname(os.path.realpath(__file__))
+base_directory = os.path.realpath(os.path.join(test_directory, '..'))
 
 # Fix flake8 undefined names (F821)
 __hug__ = __hug__  # noqa
@@ -544,7 +547,7 @@ def test_stream_return():
     """Test to ensure that its valid for a hug API endpoint to return a stream"""
     @hug.get(output=hug.output_format.text)
     def test():
-        return open('README.md', 'rb')
+        return open(os.path.join(base_directory, 'README.md'), 'rb')
 
     assert 'hug' in hug.test.get(api, 'test').data
 
@@ -863,7 +866,7 @@ def test_cli_file_return():
     """Test to ensure that its possible to return a file stream from a CLI"""
     @hug.cli()
     def test():
-        return open('README.md', 'rb')
+        return open(os.path.join(base_directory, 'README.md'), 'rb')
 
     assert 'hug' in hug.test.cli(test)
 
@@ -929,7 +932,7 @@ def test_static_file_support():
     """Test to ensure static file routing works as expected"""
     @hug.static('/static')
     def my_static_dirs():
-        return ('', )
+        return (base_directory, )
 
     assert 'hug' in hug.test.get(api, '/static/README.md').data
     assert 'Index' in hug.test.get(api, '/static/tests/data').data

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -23,10 +23,15 @@ from collections import namedtuple
 from datetime import datetime
 from decimal import Decimal
 from io import BytesIO
+import os
 
 import pytest
 
 import hug
+
+
+test_directory = os.path.dirname(os.path.realpath(__file__))
+base_directory = os.path.realpath(os.path.join(test_directory, '..'))
 
 
 def test_text():
@@ -39,7 +44,7 @@ def test_html():
     """Ensure that it's possible to output a Hug API method as HTML"""
     hug.output_format.html("<html>Hello World!</html>") == "<html>Hello World!</html>"
     hug.output_format.html(str(1)) == "1"
-    with open('README.md', 'rb') as html_file:
+    with open(os.path.join(base_directory, 'README.md'), 'rb') as html_file:
         assert hasattr(hug.output_format.html(html_file), 'read')
 
     class FakeHTMLWithRender():
@@ -79,7 +84,7 @@ def test_json():
     data = [Decimal(1.5), Decimal("155.23"), Decimal("1234.25")]
     assert hug.input_format.json(BytesIO(hug.output_format.json(data))) == ["1.5", "155.23", "1234.25"]
 
-    with open('README.md', 'rb') as json_file:
+    with open(os.path.join(base_directory, 'README.md'), 'rb') as json_file:
         assert hasattr(hug.output_format.json(json_file), 'read')
 
     assert hug.input_format.json(BytesIO(hug.output_format.json(b'\x9c'))) == 'nA=='
@@ -113,8 +118,9 @@ def test_json_camelcase():
 
 def test_image():
     """Ensure that it's possible to output images with hug"""
-    assert hasattr(hug.output_format.png_image('artwork/logo.png', hug.Response()), 'read')
-    with open('artwork/logo.png', 'rb') as image_file:
+    logo_path = os.path.join(base_directory, 'artwork', 'logo.png')
+    assert hasattr(hug.output_format.png_image(logo_path, hug.Response()), 'read')
+    with open(logo_path, 'rb') as image_file:
         assert hasattr(hug.output_format.png_image(image_file, hug.Response()), 'read')
 
     assert hug.output_format.png_image('Not Existent', hug.Response()) is None
@@ -140,10 +146,11 @@ def test_file():
     class FakeResponse(object):
         pass
 
+    logo_path = os.path.join(base_directory, 'artwork', 'logo.png')
     fake_response = FakeResponse()
-    assert hasattr(hug.output_format.file('artwork/logo.png', fake_response), 'read')
+    assert hasattr(hug.output_format.file(logo_path, fake_response), 'read')
     assert fake_response.content_type == 'image/png'
-    with open('artwork/logo.png', 'rb') as image_file:
+    with open(logo_path, 'rb') as image_file:
         hasattr(hug.output_format.file(image_file, fake_response), 'read')
 
     assert not hasattr(hug.output_format.file('NON EXISTENT FILE', fake_response), 'read')
@@ -151,8 +158,9 @@ def test_file():
 
 def test_video():
     """Ensure that it's possible to output videos with hug"""
-    assert hasattr(hug.output_format.mp4_video('artwork/example.gif', hug.Response()), 'read')
-    with open('artwork/example.gif', 'rb') as image_file:
+    gif_path = os.path.join(base_directory, 'artwork', 'example.gif')
+    assert hasattr(hug.output_format.mp4_video(gif_path, hug.Response()), 'read')
+    with open(gif_path, 'rb') as image_file:
         assert hasattr(hug.output_format.mp4_video(image_file, hug.Response()), 'read')
 
     assert hug.output_format.mp4_video('Not Existent', hug.Response()) is None


### PR DESCRIPTION
This PR lets you execute ``py.test`` even if your current working directory is not the repository root.