### PR TITLE
Distribute tests on all CPU cores

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -3,6 +3,7 @@ flake8==2.4.1
 isort==4.2.2
 marshmallow==2.6.0
 pytest-cov==2.2.1
+pytest-xdist==1.14
 pytest==2.9.0
 python-coveralls==2.7.0
 wheel==0.29.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -5,6 +5,7 @@ frosted==1.4.1
 ipython==4.1.1
 isort==4.2.2
 pytest-cov==2.2.1
+pytest-xdist==1.14
 pytest==2.9.0
 python-coveralls==2.7.0
 tox==2.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py33, py34, py35
 deps=-rrequirements/build.txt
 whitelist_externals=flake8
 commands=flake8
-    py.test --cov hug tests
+    py.test --cov hug -n auto tests
     coverage html
 
 [tox:travis]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist=py33, py34, py35
 [testenv]
 deps=-rrequirements/build.txt
 whitelist_externals=flake8
-commands=flake8
+commands=flake8 hug
     py.test --cov hug -n auto tests
     coverage html
 


### PR DESCRIPTION
This PR uses pytest-xdist to execute the unit tests in parallel and is configured to make use of all the available CPU cores. On my machine this made the tests run in 3 instead of 12 seconds.
