### PR TITLE
Bugfix/windows compatible sockets

### DIFF
--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -149,7 +149,12 @@ class TestSocket(object):
     def test_protocols(self):
         """Test to ensure all supported protocols are present"""
         protocols = sorted(['tcp', 'udp', 'unix_stream', 'unix_dgram'])
-        assert sorted(self.tcp_service.protocols) == protocols
+        if self.on_unix:
+            assert sorted(self.tcp_service.protocols) == protocols
+        else:
+            protocols.remove('unix_stream')
+            protocols.remove('unix_dgram')
+            assert sorted(self.tcp_service.protocols) == protocols
 
     def test_streams(self):
         if self.on_unix:

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -138,6 +138,7 @@ class TestLocal(object):
 
 class TestSocket(object):
     """Test to ensure the Socket Service object enables sending/receiving data from arbitrary server/port sockets"""
+    on_unix = getattr(socket, 'AF_UNIX', False)
     tcp_service = use.Socket(connect_to=('www.google.com', 80), proto='tcp', timeout=60)
     udp_service = use.Socket(connect_to=('8.8.8.8', 53), proto='udp', timeout=60)
 
@@ -151,10 +152,16 @@ class TestSocket(object):
         assert sorted(self.tcp_service.protocols) == protocols
 
     def test_streams(self):
-        assert self.tcp_service.streams == ('tcp', 'unix_stream')
+        if self.on_unix:
+            assert self.tcp_service.streams == {'tcp', 'unix_stream'}
+        else:
+            assert self.tcp_service.streams == {'tcp'}
 
     def test_datagrams(self):
-        assert self.tcp_service.datagrams == ('udp', 'unix_dgram')
+        if self.on_unix:
+            assert self.tcp_service.datagrams == {'udp', 'unix_dgram'}
+        else:
+            assert self.tcp_service.datagrams == {'udp'}
 
     def test_connection(self):
         assert self.tcp_service.connection.connect_to == ('www.google.com', 80)

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -163,6 +163,15 @@ class TestSocket(object):
         else:
             assert self.tcp_service.datagrams == {'udp'}
 
+    def test_inet(self):
+        assert self.tcp_service.inet == {'tcp', 'udp'}
+
+    def test_unix(self):
+        if self.on_unix:
+            assert self.tcp_service.unix == {'unix_stream', 'unix_dgram'}
+        else:
+            assert self.tcp_service.unix == set()
+
     def test_connection(self):
         assert self.tcp_service.connection.connect_to == ('www.google.com', 80)
         assert self.tcp_service.connection.proto == 'tcp'

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -158,22 +158,22 @@ class TestSocket(object):
 
     def test_streams(self):
         if self.on_unix:
-            assert self.tcp_service.streams == {'tcp', 'unix_stream'}
+            assert self.tcp_service.streams == set(('tcp', 'unix_stream',))
         else:
-            assert self.tcp_service.streams == {'tcp'}
+            assert self.tcp_service.streams == set(('tcp',))
 
     def test_datagrams(self):
         if self.on_unix:
-            assert self.tcp_service.datagrams == {'udp', 'unix_dgram'}
+            assert self.tcp_service.datagrams == set(('udp', 'unix_dgram',))
         else:
-            assert self.tcp_service.datagrams == {'udp'}
+            assert self.tcp_service.datagrams == set(('udp',))
 
     def test_inet(self):
-        assert self.tcp_service.inet == {'tcp', 'udp'}
+        assert self.tcp_service.inet == set(('tcp', 'udp',))
 
     def test_unix(self):
         if self.on_unix:
-            assert self.tcp_service.unix == {'unix_stream', 'unix_dgram'}
+            assert self.tcp_service.unix == set(('unix_stream', 'unix_dgram',))
         else:
             assert self.tcp_service.unix == set()
 


### PR DESCRIPTION
This PR proposes a solution for reported issue #265. I forgot to add Windows support, these changes make the appropriate checks to fill in the `use.Socket` attributes according to the platform `hug` is being executed on.

* Improves tests to support Windows and other style changes.
* Adds the ability to use `use.Socket` in a Windows environment, previous emergency bugfix does not declare `use.Socket` if `AF_UNIX` is not a valid socket attribute.