### PR TITLE
Fix example for extending API

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Or alternatively - for cases like this - where only one module is being included
 
 ```py
 #alternatively
-__hug__.extend(something, '/something')
+hug.API(__name__).extend(something, '/something')
 ```
 
 


### PR DESCRIPTION
Looks like the API changed and the example in the README wasn't updated.