### PR TITLE
Added travis configuration to test under OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,28 @@
 language: python
-python:
-  - "3.3"
-  - "3.4"
-  - "3.5"
+
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      python: 3.3
+    - os: linux
+      sudo: required
+      python: 3.4
+    - os: linux
+      sudo: required
+      python: 3.5
+    - os: osx
+      language: generic
+      env: TOXENV=py34
+    - os: osx
+      language: generic
+      env: TOXENV=py35
+
+before_install:
+  - ./scripts/before_install.sh
+
 install:
+  - source ./scripts/install.sh
   - pip install tox tox-travis coveralls
 script: tox
 after_success: coveralls

--- a/hug/use.py
+++ b/hug/use.py
@@ -243,7 +243,7 @@ class Socket(Service):
 
     def _dgram_send_and_receive(self, _socket, message, buffer_size=4096, *args):
         """User Datagram Protocol sender and receiver"""
-        _socket.sendto(message.encode('utf-8'), self.connection.connect_to)
+        _socket.send(message.encode('utf-8'))
         data, address = _socket.recvfrom(buffer_size)
         return BytesIO(data)
 

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -1,0 +1,24 @@
+#! /bin/bash
+
+echo $TRAVIS_OS_NAME
+
+ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+
+    # Travis has an old version of pyenv by default, upgrade it
+    brew update > /dev/null 2>&1
+    brew outdated pyenv || brew upgrade pyenv
+
+    pyenv --version
+
+    # Find the latest requested version of python
+    case "$TOXENV" in
+        py34)
+            python_minor=4;;
+        py35)
+            python_minor=5;;
+    esac
+    latest_version=`pyenv install --list | grep -e "^[ ]*3\.$python_minor" | tail -1`
+
+    pyenv install $latest_version
+    pyenv local $latest_version
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+
+    # enable pyenv shims to activate the proper python version
+    eval "$(pyenv init -)"
+
+    # Log some information on the environment
+    pyenv local
+    which python
+    which pip
+    python --version
+    python -m pip --version
+fi


### PR DESCRIPTION
Fixes #282 

This PR adds some scripts to install the proper python on the Travis worker and allows to test on OSX.
Also included is a fix for the failing test on OSX.

Currently the strategy is to have a worker per python version as with the Linux build. The downside is that Travis' OSX worker are limited in capacity and the build could be delayed by several tens of minutes in peak hours. In the event that the build is repeatably blocked by the OSX workers, we could move all the tests in a single worker.


