### PR TITLE
Fix ValueError being raised when using versions

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -181,7 +181,8 @@ class HTTPInterfaceAPI(InterfaceAPI):
         version_dict = OrderedDict()
         versions = self.versions
         versions_list = list(versions)
-        versions_list.remove(None)
+        if None in versions_list:
+            versions_list.remove(None)
         if api_version is None and len(versions_list) > 0:
             api_version = max(versions_list)
             documentation['version'] = api_version


### PR DESCRIPTION
Hi,
The `2.0.6` version from PIP is raising a ValueError when using versioning. The traceback (running using `gunicorn module:__hug_wsgi__ --reload -b 127.0.0.1:8080`

```python
[6257] [ERROR] Error handling request /
Traceback (most recent call last):
  File "/Users/prashantsinha/.virtualenvs/jupiter/lib/python3.5/site-packages/gunicorn/workers/sync.py", line 130, in handle
    self.handle_request(listener, req, client, addr)
  File "/Users/prashantsinha/.virtualenvs/jupiter/lib/python3.5/site-packages/gunicorn/workers/sync.py", line 171, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/Users/prashantsinha/.virtualenvs/jupiter/lib/python3.5/site-packages/hug/api.py", line 378, in api_auto_instantiate
    return module.__hug_wsgi__(*kargs, **kwargs)
  File "/Users/prashantsinha/.virtualenvs/jupiter/lib/python3.5/site-packages/falcon/api.py", line 182, in __call__
    responder(req, resp, **params)
  File "/Users/prashantsinha/.virtualenvs/jupiter/lib/python3.5/site-packages/hug/api.py", line 278, in version_router
    **kwargs)
  File "/Users/prashantsinha/.virtualenvs/jupiter/lib/python3.5/site-packages/hug/api.py", line 266, in handle_404
    to_return['documentation'] = self.documentation(url_prefix, self.determine_version(request, False))
  File "/Users/prashantsinha/.virtualenvs/jupiter/lib/python3.5/site-packages/hug/api.py", line 184, in documentation
    versions_list.remove(None)
ValueError: list.remove(x): x not in list
```
The fix is implemented in this PR.

Thanks