### PR TITLE
Added support asyncio methods 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,4 +4,4 @@ exclude_lines = def hug
                 def serve
                 sys.stdout.buffer.write
                 class Socket
-
+                pragma: no cover

--- a/README.md
+++ b/README.md
@@ -307,6 +307,31 @@ def not_found_handler():
 ```
 
 
+Asyncio support
+===============
+
+When using the `get` and `cli` method decorator on coroutines, hug will schedule
+the execution of the coroutine.
+
+Using asyncio coroutine decorator
+```py
+@hug.get()
+@asyncio.coroutine
+def hello_world():
+    return "Hello"
+```
+
+Using Python 3.5 async keyword.
+```py
+@hug.get()
+async def hello_world():
+    return "Hello"
+```
+
+NOTE: Hug is running on top Falcon which is not an asynchronous server. Even if using
+asyncio, requests will still be processed synchronously.
+
+
 Why hug?
 ===================
 

--- a/hug/directives.py
+++ b/hug/directives.py
@@ -111,7 +111,7 @@ class CurrentAPI(object):
         if not function:
             raise AttributeError('API Function {0} not found'.format(name))
 
-        accepts = introspect.arguments(function.interface.function)
+        accepts = function.interface.arguments
         if 'hug_api_version' in accepts:
             function = partial(function, hug_api_version=self.api_version)
         if 'hug_current_api' in accepts:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+
+import sys
+
+collect_ignore = []
+
+if sys.version_info < (3, 5):
+    collect_ignore.append("test_async.py")
+
+if sys.version_info < (3, 4):
+    collect_ignore.append("test_coroutines.py")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,86 @@
+"""hug/test.py.
+
+Tests the support for asynchronous method using asyncio async def
+
+Copyright (C) 2016  Timothy Edmund Crosley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+
+import asyncio
+
+import hug
+
+
+loop = asyncio.get_event_loop()
+api = hug.API(__name__)
+
+
+def test_basic_call_async():
+    """ The most basic Happy-Path test for Hug APIs using async """
+    @hug.call()
+    async def hello_world():
+        return "Hello World!"
+
+    assert loop.run_until_complete(hello_world()) == "Hello World!"
+
+
+def test_basic_call_on_method_async():
+
+    """Test to ensure the most basic call still works if applied to a method"""
+    class API(object):
+
+        @hug.call()
+        async def hello_world(self=None):
+            return "Hello World!"
+
+    api_instance = API()
+    assert api_instance.hello_world.interface.http
+    assert loop.run_until_complete(api_instance.hello_world()) == "Hello World!"
+    assert hug.test.get(api, '/hello_world').data == "Hello World!"
+
+
+def test_basic_call_on_method_through_api_instance_async():
+
+    class API(object):
+
+        def hello_world(self):
+            return "Hello World!"
+
+    api_instance = API()
+
+    @hug.call()
+    async def hello_world():
+        return api_instance.hello_world()
+
+    assert api_instance.hello_world() == "Hello World!"
+    assert hug.test.get(api, '/hello_world').data == "Hello World!"
+
+
+def test_basic_call_on_method_registering_without_decorator_async():
+
+    class API(object):
+
+        def __init__(self):
+            hug.call()(self.hello_world_method)
+
+        async def hello_world_method(self):
+            return "Hello World!"
+
+    api_instance = API()
+
+    assert loop.run_until_complete(api_instance.hello_world_method()) == "Hello World!"
+    assert hug.test.get(api, '/hello_world_method').data == "Hello World!"

--- a/tests/test_coroutines.py
+++ b/tests/test_coroutines.py
@@ -1,0 +1,89 @@
+"""hug/test.py.
+
+Tests the support for asynchronous method using asyncio coroutines
+
+Copyright (C) 2016  Timothy Edmund Crosley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+"""
+import asyncio
+
+import hug
+
+
+loop = asyncio.get_event_loop()
+api = hug.API(__name__)
+
+
+def test_basic_call_coroutine():
+    """ The most basic Happy-Path test for Hug APIs using async """
+    @hug.call()
+    @asyncio.coroutine
+    def hello_world():
+        return "Hello World!"
+
+    assert loop.run_until_complete(hello_world()) == "Hello World!"
+
+
+def test_basic_call_on_method_coroutine():
+
+    """Test to ensure the most basic call still works if applied to a method"""
+    class API(object):
+
+        @hug.call()
+        @asyncio.coroutine
+        def hello_world(self=None):
+            return "Hello World!"
+
+    api_instance = API()
+    assert api_instance.hello_world.interface.http
+    assert loop.run_until_complete(api_instance.hello_world()) == "Hello World!"
+    assert hug.test.get(api, '/hello_world').data == "Hello World!"
+
+
+def test_basic_call_on_method_through_api_instance_coroutine():
+
+    class API(object):
+
+        def hello_world(self):
+            return "Hello World!"
+
+    api_instance = API()
+
+    @hug.call()
+    @asyncio.coroutine
+    def hello_world():
+        return api_instance.hello_world()
+
+    assert api_instance.hello_world() == "Hello World!"
+    assert hug.test.get(api, '/hello_world').data == "Hello World!"
+
+
+def test_basic_call_on_method_registering_without_decorator_coroutine():
+
+    class API(object):
+
+        def __init__(self):
+            hug.call()(self.hello_world_method)
+
+        @asyncio.coroutine
+        def hello_world_method(self):
+            return "Hello World!"
+
+    api_instance = API()
+
+    assert loop.run_until_complete(api_instance.hello_world_method()) == "Hello World!"
+    assert hug.test.get(api, '/hello_world_method').data == "Hello World!"

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py33, py34, py35
 deps=-rrequirements/build.txt
 whitelist_externals=flake8
 commands=flake8 hug
-    py.test --cov hug tests
+    py.test --cov-report term-missing --cov hug tests
     coverage html
 
 [tox:travis]


### PR DESCRIPTION
fixes #241 

This PR aims to enable support for coroutines within hug framework. Coroutines called through the web server or the cli will automatically be scheduled on the asyncio default event loop. This allows to use async code in decorated functions.

This PR does not enable asynchronous requests for the http server.
