### PR TITLE
Parse urlencoded request bodies into Python dicts

### DIFF
--- a/hug/defaults.py
+++ b/hug/defaults.py
@@ -27,6 +27,7 @@ output_format = hug.output_format.json
 
 input_format = {
     'application/json': hug.input_format.json,
+    'application/x-www-form-urlencoded': hug.input_format.urlencoded,
     'text/plain': hug.input_format.text,
     'text/css': hug.input_format.text,
     'text/html': hug.input_format.text

--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import json as json_converter
 import re
+from urllib.parse import parse_qs as urlencoded_converter
 
 from hug.format import content_type, underscore
 
@@ -70,3 +71,9 @@ def json_underscore(body, encoding='utf-8'):
     The keys in any JSON dict are transformed from camelcase to underscore separated words.
     """
     return _underscore_dict(json(body, encoding=encoding))
+
+
+@content_type('application/x-www-form-urlencoded')
+def urlencoded(body, encoding='utf-8'):
+    """Converts query strings into native Python objects"""
+    return urlencoded_converter(text(body, encoding=encoding))

--- a/tests/test_input_format.py
+++ b/tests/test_input_format.py
@@ -47,3 +47,9 @@ def test_separate_encoding():
     assert hug.input_format.separate_encoding('text/html; charset=utf8') == ('text/html', 'utf8')
     assert hug.input_format.separate_encoding('text/html', 'default') == ('text/html', 'default')
     assert hug.input_format.separate_encoding('text/html; chset=malformatted') == ('text/html', None)
+
+def test_urlencoded():
+    """Ensure that urlencoded input format works as intended"""
+    test_data = BytesIO(b'foo=baz&foo=bar&name=John+Doe')
+    assert hug.input_format.urlencoded(test_data) == {'name': ['John Doe'], 'foo': ['baz', 'bar']}
+


### PR DESCRIPTION
`application/x-www-form-urlencoded` POST bodies are the norm for HTML forms, the default format for the requests library, and often used by the IETF RFCs. Having this as a default format would really help developers working with standards.