### PR TITLE
`multipart/form-data` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changelog
 ### 2.1.0 (in Development)
 - Updated base Falcon requirement to the latest: 1.0.0
 - Added native support for using asyncio methods (Thanks @rodcloutier!)
-- Added improved support for `application/x-www-form-urlencoded` forms (thanks @cog!)
+- Added improved support for `application/x-www-form-urlencoded` forms (thanks @cag!)
 - Added support for getting URL from hug function
 - Added support for using `hug.local()` on methods in addition to functions
 - Added a default mime-type for static file endpoints (`application/octet-stream`)

--- a/hug/defaults.py
+++ b/hug/defaults.py
@@ -28,6 +28,7 @@ output_format = hug.output_format.json
 input_format = {
     'application/json': hug.input_format.json,
     'application/x-www-form-urlencoded': hug.input_format.urlencoded,
+    'multipart/form-data': hug.input_format.multipart,
     'text/plain': hug.input_format.text,
     'text/css': hug.input_format.text,
     'text/html': hug.input_format.text

--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import json as json_converter
 import re
+from cgi import parse_multipart
 from urllib.parse import parse_qs as urlencoded_converter
 
 from falcon.util.uri import parse_query_string
@@ -69,3 +70,16 @@ def json_underscore(body, header_params={'charset': 'utf-8'}):
 def urlencoded(body, header_params={'charset': 'ascii'}):
     """Converts query strings into native Python objects"""
     return parse_query_string(text(body, header_params=header_params), False)
+
+
+@content_type('multipart/form-data')
+def multipart(body, header_params=None):
+    """Converts multipart form data into native Python objects"""
+    if 'boundary' in header_params:
+        if type(header_params['boundary']) is str:
+            header_params['boundary'] = header_params['boundary'].encode()
+    form = parse_multipart(body, header_params)
+    for k, v in form.items():
+        if type(v) is list and len(v) is 1:
+            form[k] = v[0]
+    return form

--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -29,20 +29,6 @@ from falcon.util.uri import parse_query_string
 
 from hug.format import content_type, underscore
 
-RE_CHARSET = re.compile("charset=(?P<charset>[^;]+)")
-
-
-def separate_encoding(content_type, default=None):
-    """Separates out the encoding from the content_type and returns both in a tuple (content_type, encoding)"""
-    encoding = default
-    if content_type and ";" in content_type:
-        content_type, rest = content_type.split(";", 1)
-        charset = RE_CHARSET.search(rest)
-        if charset:
-            encoding = charset.groupdict().get('charset', encoding).strip()
-
-    return (content_type, encoding)
-
 
 @content_type('text/plain')
 def text(body, encoding='utf-8'):

--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -75,7 +75,7 @@ def urlencoded(body, header_params={'charset': 'ascii'}):
 @content_type('multipart/form-data')
 def multipart(body, header_params=None):
     """Converts multipart form data into native Python objects"""
-    if 'boundary' in header_params:
+    if header_params and 'boundary' in header_params:
         if type(header_params['boundary']) is str:
             header_params['boundary'] = header_params['boundary'].encode()
     form = parse_multipart(body, header_params)

--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -31,15 +31,19 @@ from hug.format import content_type, underscore
 
 
 @content_type('text/plain')
-def text(body, encoding='utf-8'):
+def text(body, header_params={'charset': 'utf-8'}):
     """Takes plain text data"""
-    return body.read().decode(encoding)
+    encoding = header_params and header_params.get('charset', None)
+    data = body.read()
+    if encoding:
+        return data.decode(encoding)
+    return data.decode()
 
 
 @content_type('application/json')
-def json(body, encoding='utf-8'):
+def json(body, header_params={'charset': 'utf-8'}):
     """Takes JSON formatted data, converting it into native Python objects"""
-    return json_converter.loads(text(body, encoding=encoding))
+    return json_converter.loads(text(body, header_params=header_params))
 
 
 def _underscore_dict(dictionary):
@@ -53,15 +57,15 @@ def _underscore_dict(dictionary):
     return new_dictionary
 
 
-def json_underscore(body, encoding='utf-8'):
+def json_underscore(body, header_params={'charset': 'utf-8'}):
     """Converts JSON formatted date to native Python objects.
 
     The keys in any JSON dict are transformed from camelcase to underscore separated words.
     """
-    return _underscore_dict(json(body, encoding=encoding))
+    return _underscore_dict(json(body, header_params=header_params))
 
 
 @content_type('application/x-www-form-urlencoded')
-def urlencoded(body, encoding='ascii'):
+def urlencoded(body, header_params={'charset': 'ascii'}):
     """Converts query strings into native Python objects"""
-    return parse_query_string(text(body, encoding=encoding), False)
+    return parse_query_string(text(body, header_params=header_params), False)

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -445,10 +445,9 @@ class HTTP(Interface):
         if self.parse_body and request.content_length is not None:
             body = request.stream
             content_type, ct_params = parse_header(request.content_type)
-            encoding = ct_params.get('charset', None)
             body_formatter = body and self.api.http.input_format(content_type)
             if body_formatter:
-                body = body_formatter(body, encoding) if encoding is not None else body_formatter(body)
+                body = body_formatter(body, ct_params) if ct_params else body_formatter(body)
             if 'body' in self.parameters:
                 input_parameters['body'] = body
             if isinstance(body, dict):

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 import argparse
 import os
 import sys
+from cgi import parse_header
 from collections import OrderedDict
 from functools import lru_cache, partial, wraps
 
@@ -36,7 +37,6 @@ import hug.output_format
 import hug.types as types
 from hug import introspect
 from hug.exceptions import InvalidTypeData
-from hug.input_format import separate_encoding
 from hug.types import MarshmallowSchema, Multiple, OneOf, SmartBoolean, Text, text
 
 try:
@@ -444,7 +444,8 @@ class HTTP(Interface):
         input_parameters.update(request.params)
         if self.parse_body and request.content_length is not None:
             body = request.stream
-            content_type, encoding = separate_encoding(request.content_type)
+            content_type, ct_params = parse_header(request.content_type)
+            encoding = ct_params.get('charset', None)
             body_formatter = body and self.api.http.input_format(content_type)
             if body_formatter:
                 body = body_formatter(body, encoding) if encoding is not None else body_formatter(body)

--- a/hug/use.py
+++ b/hug/use.py
@@ -111,7 +111,7 @@ class HTTP(Service):
         data = BytesIO(response.content)
         content_type, ct_params = parse_header(response.headers.get('content-type', ''))
         if content_type in input_format:
-            data = input_format[content_type](data, ct_params.get('charset', 'utf-8'))
+            data = input_format[content_type](data, ct_params or {'charset': 'utf-8'})
 
         if response.status_code in self.raise_on:
             raise requests.HTTPError('{0} {1} occured for url: {2}'.format(response.status_code, response.reason, url))
@@ -153,7 +153,7 @@ class Local(Service):
         data = BytesIO(response.data)
         content_type, ct_params = parse_header(response._headers.get('content-type', ''))
         if content_type in input_format:
-            data = input_format[content_type](data, ct_params.get('charset', 'utf-8'))
+            data = input_format[content_type](data, ct_params or {'charset': 'utf-8'})
 
         status_code = int(''.join(re.findall('\d+', response.status)))
         if status_code in self.raise_on:

--- a/hug/use.py
+++ b/hug/use.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 
 import re
 import socket
+from cgi import parse_header
 from collections import namedtuple
 from io import BytesIO
 from queue import Queue
@@ -33,7 +34,6 @@ import requests
 import hug._empty as empty
 from hug.api import API
 from hug.defaults import input_format
-from hug.input_format import separate_encoding
 
 Response = namedtuple('Response', ('data', 'status_code', 'headers'))
 Request = namedtuple('Request', ('content_length', 'stream', 'params'))
@@ -109,9 +109,9 @@ class HTTP(Service):
         response = self.session.request(method, self.endpoint + url.format(url_params), headers=headers, **kwargs)
 
         data = BytesIO(response.content)
-        (content_type, encoding) = separate_encoding(response.headers.get('content-type', ''), 'utf-8')
+        content_type, ct_params = parse_header(response.headers.get('content-type', ''))
         if content_type in input_format:
-            data = input_format[content_type](data, encoding)
+            data = input_format[content_type](data, ct_params.get('charset', 'utf-8'))
 
         if response.status_code in self.raise_on:
             raise requests.HTTPError('{0} {1} occured for url: {2}'.format(response.status_code, response.reason, url))
@@ -151,9 +151,9 @@ class Local(Service):
             interface.render_content(interface.call_function(**params), request, response)
 
         data = BytesIO(response.data)
-        (content_type, encoding) = separate_encoding(response._headers.get('content-type', ''), 'utf-8')
+        content_type, ct_params = parse_header(response._headers.get('content-type', ''))
         if content_type in input_format:
-            data = input_format[content_type](data, encoding)
+            data = input_format[content_type](data, ct_params.get('charset', 'utf-8'))
 
         status_code = int(''.join(re.findall('\d+', response.status)))
         if status_code in self.raise_on:

--- a/tests/test_input_format.py
+++ b/tests/test_input_format.py
@@ -42,13 +42,6 @@ def test_json_underscore():
     assert hug.input_format.json_underscore(test_data) == {'camel_case': {'because_we_can': 'ValueExempt'}}
 
 
-def test_separate_encoding():
-    """Test to ensure separating out encodings from content_types works as expected"""
-    assert hug.input_format.separate_encoding('text/html; charset=utf8') == ('text/html', 'utf8')
-    assert hug.input_format.separate_encoding('text/html', 'default') == ('text/html', 'default')
-    assert hug.input_format.separate_encoding('text/html; chset=malformatted') == ('text/html', None)
-
-
 def test_urlencoded():
     """Ensure that urlencoded input format works as intended"""
     test_data = BytesIO(b'foo=baz&foo=bar&name=John+Doe')

--- a/tests/test_input_format.py
+++ b/tests/test_input_format.py
@@ -19,9 +19,15 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
+import os
+from cgi import parse_header
 from io import BytesIO
 
+import requests
+
 import hug
+
+from .constants import BASE_DIRECTORY
 
 
 def test_text():
@@ -48,3 +54,11 @@ def test_urlencoded():
     """Ensure that urlencoded input format works as intended"""
     test_data = BytesIO(b'foo=baz&foo=bar&name=John+Doe')
     assert hug.input_format.urlencoded(test_data) == {'name': 'John Doe', 'foo': ['baz', 'bar']}
+
+
+def test_multipart():
+    """Ensure multipart form data works as intended"""
+    with open(os.path.join(BASE_DIRECTORY, 'artwork', 'koala.png'),'rb') as koala:
+        preq = requests.Request('POST', 'http://localhost/', files={'koala': koala}).prepare()
+        koala.seek(0)
+        assert hug.input_format.multipart(BytesIO(preq.body), parse_header(preq.headers['Content-Type'])[1])['koala'] == koala.read()

--- a/tests/test_input_format.py
+++ b/tests/test_input_format.py
@@ -28,6 +28,8 @@ def test_text():
     """Ensure that plain text input format works as intended"""
     test_data = BytesIO(b'{"a": "b"}')
     assert hug.input_format.text(test_data) == '{"a": "b"}'
+    test_data = BytesIO(b'{"a": "b"}')
+    assert hug.input_format.text(test_data, None) == '{"a": "b"}'
 
 
 def test_json():


### PR DESCRIPTION
This is a fairly substantial change, as it requires getting more MIME header information to the formatter, so I decided to change the signature of the input formatters as the encoding parameter has not been documented yet(?)