### PR TITLE
Update default formatter documentation

### DIFF
--- a/documentation/OUTPUT_FORMATS.md
+++ b/documentation/OUTPUT_FORMATS.md
@@ -5,7 +5,7 @@ Every endpoint that is exposed through an externally facing interface will need 
 
 The default output format for all hug APIs is JSON. However, you may explicitly specify a different default output_format:
 
-    hug.API(__name__).output_format = hug.output_format.html
+    hug.API(__name__).http.output_format = hug.output_format.html
 
 or:
 


### PR DESCRIPTION
I was receiving an AttributeError when trying to set output_format on a hug API directly as it states in the documentation. It seems I needed to specify an interface before setting the formatter. I think the documentation needs to be updated to reflect this.