### PR TITLE
[Issue-309] Fix exception_handler setup for extend_api decorator

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -151,9 +151,11 @@ class HTTPInterfaceAPI(InterfaceAPI):
         for startup_handler in (http_api.startup_handlers or ()):
             self.add_startup_handler(startup_handler)
 
-        for version, handler in getattr(http_api, '_exception_handlers', {}).items():
+        for version, handler in getattr(self, '_exception_handlers', {}).items():
             for exception_type, exception_handler in handler.items():
-                self.add_exception_handler(exception_type, exception_handler, version)
+                target_exception_handlers = http_api.exception_handlers(version) or {}
+                if exception_type not in target_exception_handlers:
+                    http_api.add_exception_handler(exception_type, exception_handler, version)
 
         for input_format, input_format_handler in getattr(http_api, '_input_format', {}).items():
             if not input_format in getattr(self, '_input_format', {}):

--- a/tests/module_fake_simple.py
+++ b/tests/module_fake_simple.py
@@ -2,7 +2,14 @@
 import hug
 
 
+class FakeSimpleException(Exception):
+    pass
+
 @hug.get()
 def made_up_hello():
     """for science!"""
     return 'hello'
+
+@hug.get('/exception')
+def made_up_exception():
+    raise FakeSimpleException('test')

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -692,6 +692,23 @@ def test_extending_api_simple():
     assert hug.test.get(api, 'fake_simple/made_up_hello').data == 'hello'
 
 
+def test_extending_api_with_exception_handler():
+    """Test to ensure it's possible to extend the current API from an external file"""
+
+    from tests.module_fake_simple import FakeSimpleException
+
+    @hug.exception(FakeSimpleException)
+    def handle_exception(exception):
+        return 'it works!'
+
+    @hug.extend_api('/fake_simple')
+    def extend_with():
+        import tests.module_fake_simple
+        return (tests.module_fake_simple, )
+
+    assert hug.test.get(api, '/fake_simple/exception').data == 'it works!'
+
+
 def test_cli():
     """Test to ensure the CLI wrapper works as intended"""
     @hug.cli('command', '1.0.0', output=str)


### PR DESCRIPTION
This is an attempt for fixing the https://github.com/timothycrosley/hug/issues/309

extend exception handler should handled by assigning the from the base to the target instead of the other way around. This way, it will cover the following scenarios properly:

1) when exception handler is set on the base (e.g. `/base`) but not on the extended target  (e.g. `/base/extended`):
    the extended route will use the exception handler from the base

2) exception handler is NOT set on the base (e.g. `/base`) but only set on the extended target  (e.g. `/base/extended`):
    the base route will have no exception handler, and target route will use the defined exception handler

3) exception handlers are set on both base (e.g. `/base`) and extended target  (e.g. `/base/extended`):
    both routes will use their own handlers.