### PR TITLE
Optionally hide endpoints from documentation

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -195,7 +195,7 @@ class HTTPInterfaceAPI(InterfaceAPI):
         for url, methods in self.routes.items():
             for method, method_versions in methods.items():
                 for version, handler in method_versions.items():
-                    if handler.private:
+                    if getattr(handler, 'private', False):
                         continue
                     if version is None:
                         applies_to = versions

--- a/hug/api.py
+++ b/hug/api.py
@@ -195,6 +195,8 @@ class HTTPInterfaceAPI(InterfaceAPI):
         for url, methods in self.routes.items():
             for method, method_versions in methods.items():
                 for version, handler in method_versions.items():
+                    if handler.private:
+                        continue
                     if version is None:
                         applies_to = versions
                     else:

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -415,7 +415,7 @@ class HTTP(Interface):
     """Defines the interface responsible for wrapping functions and exposing them via HTTP based on the route"""
     __slots__ = ('_params_for_outputs', '_params_for_invalid_outputs', '_params_for_transform', 'on_invalid',
                  '_params_for_on_invalid', 'set_status', 'response_headers', 'transform', 'input_transformations',
-                 'examples', 'wrapped', 'catch_exceptions', 'parse_body')
+                 'examples', 'wrapped', 'catch_exceptions', 'parse_body', 'private')
     AUTO_INCLUDE = {'request', 'response'}
 
     def __init__(self, route, function, catch_exceptions=True):
@@ -425,6 +425,7 @@ class HTTP(Interface):
         self.set_status = route.get('status', False)
         self.response_headers = tuple(route.get('response_headers', {}).items())
         self.outputs = route.get('output', self.api.http.output_format)
+        self.private = 'private' in route
 
         self._params_for_outputs = introspect.takes_arguments(self.outputs, *self.AUTO_INCLUDE)
         self._params_for_transform = introspect.takes_arguments(self.transform, *self.AUTO_INCLUDE)

--- a/hug/routing.py
+++ b/hug/routing.py
@@ -183,7 +183,7 @@ class HTTPRouter(InternalValidation):
     __slots__ = ()
 
     def __init__(self, versions=None, parse_body=False, parameters=None, defaults={}, status=None,
-                 response_headers=None, **kwargs):
+                 response_headers=None, private=False, **kwargs):
         super().__init__(**kwargs)
         self.route['versions'] = (versions, ) if isinstance(versions, (int, float, None.__class__)) else versions
         if parse_body:
@@ -196,6 +196,8 @@ class HTTPRouter(InternalValidation):
             self.route['status'] = status
         if response_headers:
             self.route['response_headers'] = response_headers
+        if private:
+            self.route['private'] = private
 
     def versions(self, supported, **overrides):
         """Sets the versions that this route should be compatiable with"""

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -97,5 +97,3 @@ def test_basic_call_on_method_registering_without_decorator_async():
 
     assert loop.run_until_complete(api_instance.hello_world_method()) == "Hello World!"
     assert hug.test.get(api, '/hello_world_method').data == "Hello World!"
-
-

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -56,6 +56,11 @@ def test_basic_documentation():
         """Annotations defined with strings should be documentation only"""
         pass
 
+    @hug.get(private=True)
+    def private():
+        """Hidden from documentation"""
+        pass
+
     documentation = api.http.documentation()
     assert 'test_documentation' in documentation['overview']
 
@@ -65,6 +70,7 @@ def test_basic_documentation():
     assert not '/birthday' in documentation['handlers']
     assert '/noop' in documentation['handlers']
     assert '/string_docs' in documentation['handlers']
+    assert not '/private' in documentation['handlers']
 
     assert documentation['handlers']['/hello_world']['GET']['usage'] == "Returns hello world"
     assert documentation['handlers']['/hello_world']['GET']['examples'] == ["/hello_world"]


### PR DESCRIPTION
This PR allows some endpoints to be hidden from the automatic documentation.
```
@hug.get(private=True)
def private():
    pass
```