### PR TITLE
Unversioned-only endpoints

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -185,6 +185,8 @@ class HTTPInterfaceAPI(InterfaceAPI):
         versions_list = list(versions)
         if None in versions_list:
             versions_list.remove(None)
+        if False in versions_list:
+            versions_list.remove(False)
         if api_version is None and len(versions_list) > 0:
             api_version = max(versions_list)
             documentation['version'] = api_version
@@ -279,8 +281,9 @@ class HTTPInterfaceAPI(InterfaceAPI):
         request_version = self.determine_version(request, api_version)
         if request_version:
             request_version = int(request_version)
-        versions.get(request_version, versions.get(None, not_found))(request, response, api_version=api_version,
-                                                                     **kwargs)
+        versions.get(request_version or False, versions.get(None, not_found))(request, response,
+                                                                              api_version=api_version,
+                                                                              **kwargs)
 
     def server(self, default_not_found=True, base_url=None):
         """Returns a WSGI compatible API server for the given Hug API module"""

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -345,6 +345,10 @@ def test_versioning():
     def echo(text, api_version):
         return api_version
 
+    @hug.get('/echo', versions=False)  # noqa
+    def echo(text):
+        return "No Versions"
+
     assert hug.test.get(api, 'v1/echo', text="hi").data == 'hi'
     assert hug.test.get(api, 'v2/echo', text="hi").data == "Echo: hi"
     assert hug.test.get(api, 'v3/echo', text="hi").data == "Echo: hi"
@@ -352,7 +356,7 @@ def test_versioning():
     assert hug.test.get(api, 'echo', text="hi", headers={'X-API-VERSION': '3'}).data == "Echo: hi"
     assert hug.test.get(api, 'v4/echo', text="hi").data == "Not Implemented"
     assert hug.test.get(api, 'v7/echo', text="hi").data == 7
-    assert hug.test.get(api, 'echo', text="hi").data == "Not Implemented"
+    assert hug.test.get(api, 'echo', text="hi").data == "No Versions"
     assert hug.test.get(api, 'echo', text="hi", api_version=3, body={'api_vertion': 4}).data == "Echo: hi"
 
     with pytest.raises(ValueError):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -108,9 +108,15 @@ def test_basic_documentation():
     def unversioned():
         return 'Hello'
 
+    @hug.get(versions=False)
+    def noversions():
+        pass
+
     versioned_doc = api.http.documentation()
     assert 'versions' in versioned_doc
     assert 1 in versioned_doc['versions']
+    assert 2 in versioned_doc['versions']
+    assert False not in versioned_doc['versions']
     assert '/unversioned' in versioned_doc['handlers']
     assert '/echo' in versioned_doc['handlers']
     assert '/test' in versioned_doc['handlers']


### PR DESCRIPTION
This PR allows for endpoints that are only accessible via unversioned URLs.
```
@hug.get(versions=False)
def foo():
    pass
```
This exposes `localhost:8000/foo` but not `localhost:8000/v1/foo`.