### PR TITLE
Different base URL when extending API

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -208,7 +208,7 @@ class HTTPInterfaceAPI(InterfaceAPI):
                             continue
                         doc = version_dict.setdefault(url, OrderedDict())
                         doc[method] = handler.documentation(doc.get(method, None), version=version,
-                                                            base_url=base_url, url=url)
+                                                            base_url=handler.api.http.base_url or base_url, url=url)
 
         documentation['handlers'] = version_dict
         return documentation
@@ -312,6 +312,8 @@ class HTTPInterfaceAPI(InterfaceAPI):
 
         for url, methods in self.routes.items():
             router = {}
+            router_base_url = base_url
+
             for method, versions in methods.items():
                 method_function = "on_{0}".format(method.lower())
                 if len(versions) == 1 and None in versions.keys():
@@ -319,11 +321,14 @@ class HTTPInterfaceAPI(InterfaceAPI):
                 else:
                     router[method_function] = partial(self.version_router, versions=versions,
                                                       not_found=not_found_handler)
+                for version, handler in versions.items():
+                    router_base_url = handler.api.http.base_url or router_base_url
+                    break
 
             router = namedtuple('Router', router.keys())(**router)
-            falcon_api.add_route(base_url + url, router)
+            falcon_api.add_route(router_base_url + url, router)
             if self.versions and self.versions != (None, ):
-                falcon_api.add_route(base_url + '/v{api_version}' + url, router)
+                falcon_api.add_route(router_base_url + '/v{api_version}' + url, router)
 
         def error_serializer(_, error):
             return (self.output_format.content_type,
@@ -428,11 +433,13 @@ class API(object, metaclass=ModuleSingleton):
             self._context = {}
         return self._context
 
-    def extend(self, api, route=""):
+    def extend(self, api, route="", base_url=None):
         """Adds handlers from a different Hug API to this one - to create a single API"""
         api = API(api)
 
         if hasattr(api, '_http'):
+            if base_url is not None:
+                api.http.base_url = base_url
             self.http.extend(api.http, route)
 
         for directive in getattr(api, '_directives', {}).values():

--- a/hug/decorators.py
+++ b/hug/decorators.py
@@ -127,12 +127,12 @@ def middleware_class(api=None):
     return decorator
 
 
-def extend_api(route="", api=None):
+def extend_api(route="", api=None, base_url=None):
     """Extends the current api, with handlers from an imported api. Optionally provide a route that prefixes access"""
     def decorator(extend_with):
         apply_to_api = hug.API(api) if api else hug.api.from_object(extend_with)
         for extended_api in extend_with():
-            apply_to_api.extend(extended_api, route)
+            apply_to_api.extend(extended_api, route, base_url)
         return extend_with
     return decorator
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -713,6 +713,16 @@ def test_extending_api_with_exception_handler():
     assert hug.test.get(api, '/fake_simple/exception').data == 'it works!'
 
 
+def test_extending_api_with_base_url():
+    """Test to ensure it's possible to extend the current API with a specified base URL"""
+    @hug.extend_api('/fake', base_url='/api')
+    def extend_with():
+        import tests.module_fake
+        return (tests.module_fake, )
+
+    assert hug.test.get(api, '/api/v1/fake/made_up_api').data
+
+
 def test_cli():
     """Test to ensure the CLI wrapper works as intended"""
     @hug.cli('command', '1.0.0', output=str)


### PR DESCRIPTION
A common pattern for serving multiple APIs is to have the name of the API before the version number:
```python
example.com/foo_api/v1/echo
example.com/bar_api/v1/echo
```
This PR allows imported APIs to have different base URLs, using the existing attribute:
```python
#external.py
hug.API(__name__).http.base_url = '/foo_api'
```
Or by setting it when importing:
```python
from . import external

@hug.extend_api(base_url='/foo_api')
def external_api():
    return [external]

#alternatively
hug.API(__name__).extend(external, base_url='/foo_api')
```

