### PR TITLE
Same endpoint path under different base URLs

### DIFF
--- a/hug/interface.py
+++ b/hug/interface.py
@@ -629,12 +629,13 @@ class HTTP(Interface):
     def urls(self, version=None):
         """Returns all URLS that are mapped to this interface"""
         urls = []
-        for url, methods in self.api.http.routes.items():
-            for method, versions in methods.items():
-                for interface_version, interface in versions.items():
-                    if interface_version == version and interface == self:
-                        if not url in urls:
-                            urls.append(('/v{0}'.format(version) if version else '') + url)
+        for base_url, routes in self.api.http.routes.items():
+            for url, methods in routes.items():
+                for method, versions in methods.items():
+                    for interface_version, interface in versions.items():
+                        if interface_version == version and interface == self:
+                            if not url in urls:
+                                urls.append(('/v{0}'.format(version) if version else '') + url)
         return urls
 
     def url(self, version=None, **kwargs):

--- a/hug/routing.py
+++ b/hug/routing.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 import os
 import re
 from functools import wraps
+from collections import OrderedDict
 
 import falcon
 from falcon import HTTP_METHODS
@@ -358,6 +359,7 @@ class URLRouter(HTTPRouter):
 
     def __call__(self, api_function):
         api = self.route.get('api', hug.api.from_object(api_function))
+        api.http.routes.setdefault(api.http.base_url, OrderedDict())
         (interface, callable_method) = self._create_interface(api, api_function)
 
         use_examples = self.route.get('examples', ())
@@ -374,7 +376,7 @@ class URLRouter(HTTPRouter):
             for prefix in self.route.get('prefixes', ()):
                 expose.append(prefix + base_url)
             for url in expose:
-                handlers = api.http.routes.setdefault(url, {})
+                handlers = api.http.routes[api.http.base_url].setdefault(url, {})
                 for method in self.route.get('accept', ()):
                     version_mapping = handlers.setdefault(method.upper(), {})
                     for version in self.route['versions']:

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -723,6 +723,21 @@ def test_extending_api_with_base_url():
     assert hug.test.get(api, '/api/v1/fake/made_up_api').data
 
 
+def test_extending_api_with_same_path_under_different_base_url():
+    """Test to ensure it's possible to extend the current API with the same path under a different base URL"""
+    @hug.get()
+    def made_up_hello():
+        return 'hi'
+
+    @hug.extend_api(base_url='/api')
+    def extend_with():
+        import tests.module_fake_simple
+        return (tests.module_fake_simple, )
+
+    assert hug.test.get(api, '/made_up_hello').data == 'hi'
+    assert hug.test.get(api, '/api/made_up_hello').data == 'hello'
+
+
 def test_cli():
     """Test to ensure the CLI wrapper works as intended"""
     @hug.cli('command', '1.0.0', output=str)


### PR DESCRIPTION
Following #350, this PR allows an imported API to define an endpoint with the same URL path, as long as its base URL is different. This is accomplished by changing how `HTTPInterfaceAPI.routes` is stored. Instead of:
```python
{
    "/echo": {"GET": {...}}
}
```
It adds another level:
```python
{
    "/foo_api": {
        "/echo": {"GET": {...}}
    },
    "/bar_api": {
        "/echo": {"GET": {...}}
    }
}
```