### PR TITLE
Merge parameters of wrapped functions

### DIFF
--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1092,6 +1092,19 @@ def test_wraps():
     assert result['name'] == "Not telling"
     assert result['took']
 
+    def my_decorator_with_request(function):
+        @hug.wraps(function)
+        def decorated(request, *kargs, **kwargs):
+            kwargs['has_request'] = bool(request)
+            return function(*kargs, **kwargs)
+        return decorated
+
+    @hug.get()
+    @my_decorator_with_request
+    def do_you_have_request(has_request=False):
+        return has_request
+
+    assert hug.test.get(api, 'do_you_have_request').data
 
 
 def test_cli_with_empty_return():


### PR DESCRIPTION
This PR allows custom decorators to access parameters like `request` and `response`, without putting them in the original functions' parameter lists.
```python
def my_decorator(function):
    @hug.wraps(function)
    def decorated(request, *args, **kwargs):
        # do something with request object here
        return function(*args, **kwargs)
    return decorated

@hug.get()
@my_decorator
def foo():
    pass
```
This is useful if many endpoints are decorated, but don't make use of the parameters. Especially if the decorator's parameters need to change down the line.