### PR TITLE
Support sinks when extending API

### DIFF
--- a/hug/decorators.py
+++ b/hug/decorators.py
@@ -127,7 +127,7 @@ def middleware_class(api=None):
     return decorator
 
 
-def extend_api(route="", api=None, base_url=None):
+def extend_api(route="", api=None, base_url=""):
     """Extends the current api, with handlers from an imported api. Optionally provide a route that prefixes access"""
     def decorator(extend_with):
         apply_to_api = hug.API(api) if api else hug.api.from_object(extend_with)

--- a/hug/routing.py
+++ b/hug/routing.py
@@ -24,8 +24,8 @@ from __future__ import absolute_import
 
 import os
 import re
-from functools import wraps
 from collections import OrderedDict
+from functools import wraps
 
 import falcon
 from falcon import HTTP_METHODS
@@ -304,8 +304,8 @@ class StaticRouter(SinkRouter):
 
         api = self.route.get('api', hug.api.from_object(api_function))
         for base_url in self.route.get('urls', ("/{0}".format(api_function.__name__), )):
-            def read_file(request=None):
-                filename = request.path[len(base_url) + 1:]
+            def read_file(request=None, path=""):
+                filename = path.lstrip("/")
                 for directory in directories:
                     path = os.path.join(directory, filename)
                     if os.path.isdir(path):

--- a/tests/module_fake.py
+++ b/tests/module_fake.py
@@ -59,10 +59,17 @@ def on_startup(api):
     """for testing"""
     return
 
+
 @hug.static()
 def static():
     """for testing"""
     return ('', )
+
+
+@hug.sink('/all')
+def sink(path):
+    """for testing"""
+    return path
 
 
 @hug.exception(FakeException)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1000,6 +1000,15 @@ def test_sink_support():
 
     assert hug.test.get(api, '/all/the/things').data == '/the/things'
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Currently failing on Windows build')
+def test_sink_support_with_base_url():
+    """Test to ensure sink URL routers work when the API is extended with a specified base URL"""
+    @hug.extend_api('/fake', base_url='/api')
+    def extend_with():
+        import tests.module_fake
+        return (tests.module_fake, )
+
+    assert hug.test.get(api, '/api/fake/all/the/things').data == '/the/things'
 
 def test_cli_with_string_annotation():
     """Test to ensure CLI's work correctly with string annotations"""


### PR DESCRIPTION
This PR adds support for sinks in imported APIs. It also adds an optional `path` parameter, which gets populated with the wildcard portion of the URL:
```python
@hug.sink('/all')
def foo(path):
    return path
```
Accessing `localhost:8000/all/the/things` will yield "/the/things".