### PR TITLE
Add LICENSE and doc bits in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include *.md


### PR DESCRIPTION
I'm packaging hug for Fedora and we need to ship license files with the package.
package review link: https://bugzilla.redhat.com/show_bug.cgi?id=1372836