### PR TITLE
Support not_found handlers when extending API

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -171,6 +171,10 @@ class HTTPInterfaceAPI(InterfaceAPI):
             if not input_format in getattr(self, '_input_format', {}):
                 self.set_input_format(input_format, input_format_handler)
 
+        for version, handler in http_api.not_found_handlers.items():
+            if version not in self.not_found_handlers:
+                self.set_not_found_handler(handler, version)
+
     @property
     def not_found_handlers(self):
         return getattr(self, '_not_found_handlers', {})

--- a/tests/module_fake.py
+++ b/tests/module_fake.py
@@ -76,3 +76,9 @@ def sink(path):
 def handle_exception(exception):
     """Handles the provided exception for testing"""
     return True
+
+
+@hug.not_found()
+def not_found_handler():
+    """for testing"""
+    return True

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -327,6 +327,15 @@ def test_not_found():
     assert result.status == falcon.HTTP_NOT_FOUND
 
 
+def test_not_found_with_extended_api():
+    """Test to ensure the not_found decorator works correctly when the API is extended"""
+    @hug.extend_api()
+    def extend_with():
+        import tests.module_fake
+        return (tests.module_fake, )
+
+    assert hug.test.get(api, '/does_not_exist/yet').data is True
+
 def test_versioning():
     """Ensure that Hug correctly routes API functions based on version"""
     @hug.get('/echo')


### PR DESCRIPTION
This PR adds support for `not_found` handlers in imported APIs. The base API will take precedence if it already has a `not_found` handler for the specified version.