### PR TITLE
Filter documentation by base URL

### DIFF
--- a/hug/interface.py
+++ b/hug/interface.py
@@ -682,7 +682,7 @@ class HTTP(Interface):
 
             handler(request=request, response=response, exception=exception, **kwargs)
 
-    def documentation(self, add_to=None, version=None, base_url="", url=""):
+    def documentation(self, add_to=None, version=None, prefix="", base_url="", url=""):
         """Returns the documentation specific to an HTTP interface"""
         doc = OrderedDict() if add_to is None else add_to
 
@@ -691,7 +691,7 @@ class HTTP(Interface):
             doc['usage'] = usage
 
         for example in self.examples:
-            example_text = "{0}{1}{2}".format(base_url, '/v{0}'.format(version) if version else '', url)
+            example_text = "{0}{1}{2}{3}".format(prefix, base_url, '/v{0}'.format(version) if version else '', url)
             if isinstance(example, str):
                 example_text += "?{0}".format(example)
             doc_examples = doc.setdefault('examples', [])

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -112,6 +112,11 @@ def test_basic_documentation():
     def noversions():
         pass
 
+    @hug.extend_api('/fake', base_url='/api')
+    def extend_with():
+        import tests.module_fake_simple
+        return (tests.module_fake_simple, )
+
     versioned_doc = api.http.documentation()
     assert 'versions' in versioned_doc
     assert 1 in versioned_doc['versions']
@@ -127,6 +132,10 @@ def test_basic_documentation():
     assert '/unversioned' in specific_version_doc['handlers']
     assert specific_version_doc['handlers']['/unversioned']['GET']['requires'] == ['V1 Docs']
     assert '/test' not in specific_version_doc['handlers']
+
+    specific_base_doc = api.http.documentation(base_url='/api')
+    assert '/echo' not in specific_base_doc['handlers']
+    assert '/fake/made_up_hello' in specific_base_doc['handlers']
 
     handler = api.http.documentation_404()
     response = StartResponseMock()


### PR DESCRIPTION
This PR filters the documentation according to the `base_url` parameter. E.g., the following will only return `/api` handlers: 
```python
hug.API(__name__).http.documentation(base_url='/api')
```