### PR TITLE
Endpoint-specific input formatters

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -321,7 +321,6 @@ class HTTPInterfaceAPI(InterfaceAPI):
 
         if not_found_handler:
             falcon_api.add_sink(not_found_handler)
-            not_found_handler
             self._not_found = not_found_handler
 
         for sink_base_url, sinks in self.sinks.items():

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -469,7 +469,7 @@ class HTTP(Interface):
     """Defines the interface responsible for wrapping functions and exposing them via HTTP based on the route"""
     __slots__ = ('_params_for_outputs_state', '_params_for_invalid_outputs_state', '_params_for_transform_state',
                  '_params_for_on_invalid', 'set_status', 'response_headers', 'transform', 'input_transformations',
-                 'examples', 'wrapped', 'catch_exceptions', 'parse_body', 'private', 'on_invalid')
+                 'examples', 'wrapped', 'catch_exceptions', 'parse_body', 'private', 'on_invalid', 'inputs')
     AUTO_INCLUDE = {'request', 'response'}
 
     def __init__(self, route, function, catch_exceptions=True):
@@ -479,6 +479,7 @@ class HTTP(Interface):
         self.set_status = route.get('status', False)
         self.response_headers = tuple(route.get('response_headers', {}).items())
         self.private = 'private' in route
+        self.inputs = route.get('inputs', {})
 
         if 'on_invalid' in route:
             self._params_for_on_invalid = introspect.takes_arguments(self.on_invalid, *self.AUTO_INCLUDE)
@@ -515,7 +516,7 @@ class HTTP(Interface):
         if self.parse_body and request.content_length:
             body = request.stream
             content_type, content_params = parse_content_type(request.content_type)
-            body_formatter = body and self.api.http.input_format(content_type)
+            body_formatter = body and self.inputs.get(content_type, self.api.http.input_format(content_type))
             if body_formatter:
                 body = body_formatter(body, **content_params)
             if 'body' in self.all_parameters:

--- a/hug/routing.py
+++ b/hug/routing.py
@@ -184,7 +184,7 @@ class HTTPRouter(InternalValidation):
     __slots__ = ()
 
     def __init__(self, versions=None, parse_body=False, parameters=None, defaults={}, status=None,
-                 response_headers=None, private=False, **kwargs):
+                 response_headers=None, private=False, inputs=None, **kwargs):
         super().__init__(**kwargs)
         self.route['versions'] = (versions, ) if isinstance(versions, (int, float, None.__class__)) else versions
         if parse_body:
@@ -199,6 +199,8 @@ class HTTPRouter(InternalValidation):
             self.route['response_headers'] = response_headers
         if private:
             self.route['private'] = private
+        if inputs:
+            self.route['inputs'] = inputs
 
     def versions(self, supported, **overrides):
         """Sets the versions that this route should be compatiable with"""

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -326,6 +326,8 @@ def test_not_found():
     assert result.data == "Not Found"
     assert result.status == falcon.HTTP_NOT_FOUND
 
+    del api.http._not_found_handlers
+
 
 def test_not_found_with_extended_api():
     """Test to ensure the not_found decorator works correctly when the API is extended"""
@@ -636,6 +638,16 @@ def test_input_format():
     assert not hug.test.get(api, 'hello2').data
 
     api.http.set_input_format('application/json', old_format)
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='Currently failing on Windows build')
+def test_specific_input_format():
+    """Test to ensure the input formatter can be specified"""
+    @hug.get(inputs={'application/json': lambda a: 'formatted'})
+    def hello(body):
+        return body
+
+    assert hug.test.get(api, 'hello', body={'should': 'work'}).data == 'formatted'
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='Currently failing on Windows build')


### PR DESCRIPTION
This PR allows input formatters to be specified on a per-endpoint basis:
```python
def my_input_formatter(data):
    return ('Results', hug.input_format.json(data))

@hug.get(inputs={'application/json': my_input_formatter})
def foo():
    pass
```