### PR TITLE
Add ending "`" to style "hug.cli" as code

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,7 +118,7 @@ and that is core to hug, lives in only a few:
 
 -   `hug/api.py`: Defines the hug per-module singleton object that keeps track of all registered interfaces, alongside the associated per interface APIs (HTTPInterfaceAPI, CLIInterfaceAPI)
 -   `hug/routing.py`: holds all the data and settings that should be passed to newly created interfaces, and creates the interfaces from that data.
-    - This directly is what powers `hug.get`, `hug.cli, and all other function to interface routers
+    - This directly is what powers `hug.get`, `hug.cli`, and all other function to interface routers
     - Can be seen as a Factory for creating new interfaces
 -   `hug/interface.py`: Defines the actual interfaces that manage external interaction with your function (CLI and HTTP).
 


### PR DESCRIPTION
Before:
>This directly is what powers `hug.get`, `hug.cli, and all other...

After:
>This directly is what powers `hug.get`, `hug.cli`, and all other...