### PR TITLE
Reraise the original exception

### DIFF
--- a/hug/interface.py
+++ b/hug/interface.py
@@ -679,7 +679,7 @@ class HTTP(Interface):
                                 handler = potential_handler
 
             if not handler:
-                raise exception_type
+                raise exception
 
             handler(request=request, response=response, exception=exception, **kwargs)
 


### PR DESCRIPTION
When an exception handler excludes an exception, we need to reraise the original exception, not the type.

@timothycrosley -- Is there a docker or vagrant set up I can use to get a hug development environment set up?