### PR TITLE
Examples: fixes secure_auth_with_db

### DIFF
--- a/examples/secure_auth_with_db_example.py
+++ b/examples/secure_auth_with_db_example.py
@@ -45,14 +45,14 @@ def authenticate_user(username, password):
     :return: authenticated username
     """
     user_model = Query()
-    user = db.search(user_model.username == username)
+    user = db.search(user_model.username == username)[0]
 
     if not user:
         logger.warning("User %s not found", username)
         return False
 
-    if user[0]['password'] == hash_password(password, user[0].get('salt')):
-        return user[0]['username']
+    if user['password'] == hash_password(password, user.get('salt')):
+        return user['username']
 
     return False
 
@@ -65,9 +65,9 @@ def authenticate_key(api_key):
     :return: authenticated username
     """
     user_model = Query()
-    user = db.search(user_model.api_key == api_key)
+    user = db.search(user_model.api_key == api_key)[0]
     if user:
-        return user[0]['username']
+        return user['username']
     return False
 
 """
@@ -120,7 +120,7 @@ def get_token(authed_user: hug.directives.user):
     :return:
     """
     user_model = Query()
-    user = db.search(user_model.username == authed_user)
+    user = db.search(user_model.username == authed_user)[0]
 
     if user:
         out = {


### PR DESCRIPTION
 * Using the first element of the returned list of users in get_token(),
   because tinydb's db.search() always returns a list. This fixes
   a "TypeError: list indices must be integers, not str".
 * Refactors the variable "user" to always contain a single user dict,
   to be consistent.