### PR TITLE
Allow for binary file in testing

### DIFF
--- a/hug/test.py
+++ b/hug/test.py
@@ -57,7 +57,11 @@ def call(method, api_or_module, url, body='', headers=None, params=None, query_s
             data = BytesIO()
             for chunk in result:
                 data.write(chunk)
-            response.data = data.getvalue()
+            data = data.getvalue()
+            try:
+                response.data = data.decode('utf8')
+            except UnicodeDecodeError:
+                response.data = data
         except UnicodeDecodeError:
             response.data = result[0]
         response.content_type = response.headers_dict['content-type']

--- a/hug/test.py
+++ b/hug/test.py
@@ -54,10 +54,10 @@ def call(method, api_or_module, url, body='', headers=None, params=None, query_s
         try:
             response.data = result[0].decode('utf8')
         except TypeError:
-            response.data = []
+            data = BytesIO()
             for chunk in result:
-                response.data.append(chunk.decode('utf8'))
-            response.data = "".join(response.data)
+                data.write(chunk)
+            response.data = data.getvalue()
         except UnicodeDecodeError:
             response.data = result[0]
         response.content_type = response.headers_dict['content-type']


### PR DESCRIPTION
When using the `hug.test.get` to try to get a binary file, it fails after trying to decode the data as UTF-8. This pull request simply collects the binary data and returns it avoiding the decoding step.