### PR TITLE
use 'not in' expression in assertions for consistency

### DIFF
--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,6 +1,6 @@
 """tests/test_documentation.py.
 
-Tests the documentation generation capibilities integrated into Hug
+Tests the documentation generation capabilities integrated into Hug
 
 Copyright (C) 2016 Timothy Edmund Crosley
 
@@ -66,27 +66,27 @@ def test_basic_documentation():
     assert '/hello_world' in documentation['handlers']
     assert '/echo' in documentation['handlers']
     assert '/happy_birthday' in documentation['handlers']
-    assert not '/birthday' in documentation['handlers']
+    assert '/birthday' not in documentation['handlers']
     assert '/noop' in documentation['handlers']
     assert '/string_docs' in documentation['handlers']
-    assert not '/private' in documentation['handlers']
+    assert '/private' not in documentation['handlers']
 
     assert documentation['handlers']['/hello_world']['GET']['usage'] == "Returns hello world"
     assert documentation['handlers']['/hello_world']['GET']['examples'] == ["/hello_world"]
     assert documentation['handlers']['/hello_world']['GET']['outputs']['content_type'] == "application/json"
-    assert not 'inputs' in documentation['handlers']['/hello_world']['GET']
+    assert 'inputs' not in documentation['handlers']['/hello_world']['GET']
 
     assert 'text' in documentation['handlers']['/echo']['POST']['inputs']['text']['type']
-    assert not 'default' in documentation['handlers']['/echo']['POST']['inputs']['text']
+    assert 'default' not in documentation['handlers']['/echo']['POST']['inputs']['text']
 
     assert 'number' in documentation['handlers']['/happy_birthday']['POST']['inputs']['age']['type']
     assert documentation['handlers']['/happy_birthday']['POST']['inputs']['age']['default'] == 1
 
-    assert not 'inputs' in documentation['handlers']['/noop']['POST']
+    assert 'inputs' not in documentation['handlers']['/noop']['POST']
 
     assert documentation['handlers']['/string_docs']['GET']['inputs']['data']['type'] == 'Takes data'
     assert documentation['handlers']['/string_docs']['GET']['outputs']['type'] == 'Returns data'
-    assert not 'ignore_directive' in documentation['handlers']['/string_docs']['GET']['inputs']
+    assert 'ignore_directive' not in documentation['handlers']['/string_docs']['GET']['inputs']
 
     @hug.post(versions=1)  # noqa
     def echo(text):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -34,7 +34,7 @@ class TestRouter(object):
         """Test to ensure the route instanciates as expected"""
         assert self.route.route['transform'] == 'transform'
         assert self.route.route['output'] == 'output'
-        assert not 'api' in self.route.route
+        assert 'api' not in self.route.route
 
     def test_output(self):
         """Test to ensure modifying the output argument has the desired effect"""
@@ -106,7 +106,7 @@ class TestInternalValidation(TestRouter):
 
     def test_raise_on_invalid(self):
         """Test to ensure it's possible to set a raise on invalid handler per route"""
-        assert not 'raise_on_invalid' in self.route.route
+        assert 'raise_on_invalid' not in self.route.route
         assert self.route.raise_on_invalid().route['raise_on_invalid']
 
     def test_on_invalid(self):
@@ -124,27 +124,27 @@ class TestLocalRouter(TestInternalValidation):
 
     def test_validate(self):
         """Test to ensure changing wether a local route should validate or not works as expected"""
-        assert not 'skip_validation' in self.route.route
+        assert 'skip_validation' not in self.route.route
 
         route = self.route.validate()
-        assert not 'skip_validation' in route.route
+        assert 'skip_validation' not in route.route
 
         route = self.route.validate(False)
         assert 'skip_validation' in route.route
 
     def test_directives(self):
         """Test to ensure changing wether a local route should supply directives or not works as expected"""
-        assert not 'skip_directives' in self.route.route
+        assert 'skip_directives' not in self.route.route
 
         route = self.route.directives()
-        assert not 'skip_directives' in route.route
+        assert 'skip_directives' not in route.route
 
         route = self.route.directives(False)
         assert 'skip_directives' in route.route
 
     def test_version(self):
         """Test to ensure changing the version of a LocalRoute on the fly works"""
-        assert not 'version' in self.route.route
+        assert 'version' not in self.route.route
 
         route = self.route.version(2)
         assert 'version' in route.route
@@ -163,7 +163,7 @@ class TestHTTPRouter(TestInternalValidation):
     def test_parse_body(self):
         """Test to ensure the parsing body flag be flipped on the fly"""
         assert self.route.parse_body().route['parse_body']
-        assert not 'parse_body' in self.route.parse_body(False).route
+        assert 'parse_body' not in self.route.parse_body(False).route
 
     def test_requires(self):
         """Test to ensure requirements can be added on the fly"""


### PR DESCRIPTION
This is a small 'fix' to improve some assertion statements to use `assert x not in y` instead of `assert not x in y` for consistency with rest of the assertions :)

thanks for making Hug such a fun tool to work with! 🍺 