### PR TITLE
If we cannot call .decode return result as is

### DIFF
--- a/hug/test.py
+++ b/hug/test.py
@@ -62,7 +62,7 @@ def call(method, api_or_module, url, body='', headers=None, params=None, query_s
                 response.data = data.decode('utf8')
             except UnicodeDecodeError:
                 response.data = data
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, AttributeError):
             response.data = result[0]
         response.content_type = response.headers_dict['content-type']
         if response.content_type == 'application/json':


### PR DESCRIPTION
When writing a test for downloading a file, the request returns a string (the name of the file). Trying to call `.decode` on that string fails with an `AttributeError` as a string cannot be decoded (in Python 3?). Catching the exception and returning the result as is resolves that.