### PR TITLE
Fixing "list index out of range" in secure_auth_with_db_example.py

### DIFF
--- a/examples/secure_auth_with_db_example.py
+++ b/examples/secure_auth_with_db_example.py
@@ -45,7 +45,7 @@ def authenticate_user(username, password):
     :return: authenticated username
     """
     user_model = Query()
-    user = db.search(user_model.username == username)[0]
+    user = db.get(user_model.username == username)
 
     if not user:
         logger.warning("User %s not found", username)


### PR DESCRIPTION
As per http://tinydb.readthedocs.io/en/latest/usage.html#retrieving-data , db.get(...) will prevent TinyDB from throwing an "IndexError: list index out of range"

Calling with a non-existing username before:
```me@pc:~/tests$  hug -p 8081 -f secure_auth_with_db_example.py -c authenticate_user myuser mypw
Traceback (most recent call last):
  File "/usr/local/bin/hug", line 11, in <module>
    sys.exit(development_runner.hug.interface.cli())
  File "/usr/local/lib/python3.5/dist-packages/hug/interface.py", line 454, in __call__
    result = self.interface(**pass_to_function)
  File "/usr/local/lib/python3.5/dist-packages/hug/interface.py", line 99, in __call__
    return __hug_internal_self._function(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/hug/development_runner.py", line 71, in hug
    api.cli.commands[command]()
  File "/usr/local/lib/python3.5/dist-packages/hug/interface.py", line 454, in __call__
    result = self.interface(**pass_to_function)
  File "/usr/local/lib/python3.5/dist-packages/hug/interface.py", line 99, in __call__
    return __hug_internal_self._function(*args, **kwargs)
  File "secure_auth_with_db_example.py", line 48, in authenticate_user
    user = db.search(user_model.username == username)[0]
IndexError: list index out of range
```

After:
```me@pc:~/tests$  hug -p 8081 -f secure_auth_with_db_example.py -c authenticate_user myuser mypw
User myuser not found
False
```