### PR TITLE
Feature: ultrajson support

### DIFF
--- a/benchmarks/http/tornado_test.py
+++ b/benchmarks/http/tornado_test.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import tornado.ioloop
 import tornado.web
-import json
-
+try:
+    import ujson as json
+except ImportError:
+    import json
 
 class TextHandler(tornado.web.RequestHandler):
     def get(self):

--- a/hug/__init__.py
+++ b/hug/__init__.py
@@ -32,7 +32,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import absolute_import
 
 from falcon import *
-
 from hug import (authentication, directives, exceptions, format, input_format, introspect,
                  middleware, output_format, redirect, route, test, transform, types, use, validate)
 from hug._version import current

--- a/hug/api.py
+++ b/hug/api.py
@@ -21,7 +21,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
-import json
+try:
+    import ujson as json
+except ImportError:
+    import json
 import sys
 from collections import OrderedDict, namedtuple
 from distutils.util import strtobool

--- a/hug/api.py
+++ b/hug/api.py
@@ -21,10 +21,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
-try:
-    import ujson as json
-except ImportError:
-    import json
 import sys
 from collections import OrderedDict, namedtuple
 from distutils.util import strtobool
@@ -34,13 +30,19 @@ from types import ModuleType
 from wsgiref.simple_server import make_server
 
 import falcon
-from falcon import HTTP_METHODS
-
 import hug.defaults
 import hug.output_format
+from falcon import HTTP_METHODS
 from hug import introspect
 from hug._async import asyncio, ensure_future
 from hug._version import current
+
+try:  # pragma: no cover
+    import ujson as json
+except ImportError:
+    import json
+
+
 
 
 INTRO = """

--- a/hug/decorators.py
+++ b/hug/decorators.py
@@ -29,11 +29,10 @@ from __future__ import absolute_import
 import functools
 from collections import namedtuple
 
-from falcon import HTTP_METHODS
-
 import hug.api
 import hug.defaults
 import hug.output_format
+from falcon import HTTP_METHODS
 from hug import introspect
 from hug.format import underscore
 

--- a/hug/development_runner.py
+++ b/hug/development_runner.py
@@ -29,11 +29,12 @@ import time
 from multiprocessing import Process
 from os.path import exists
 
-import _thread as thread
 from hug._version import current
 from hug.api import API
 from hug.route import cli
 from hug.types import boolean, number
+
+import _thread as thread
 
 INIT_MODULES = list(sys.modules.keys())
 

--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -21,7 +21,12 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
-import json as json_converter
+
+
+try:
+        import ujson as json_converter
+except ImportError:
+        import json as json_converter
 import re
 from cgi import parse_multipart
 from urllib.parse import parse_qs as urlencoded_converter

--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -21,19 +21,19 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
-
-
-try:
-        import ujson as json_converter
-except ImportError:
-        import json as json_converter
 import re
 from cgi import parse_multipart
 from urllib.parse import parse_qs as urlencoded_converter
 
 from falcon.util.uri import parse_query_string
-
 from hug.format import content_type, underscore
+
+try:  # pragma: no cover
+    import ujson as json_converter
+except ImportError:
+    import json as json_converter
+
+
 
 
 @content_type('text/plain')

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -28,12 +28,11 @@ from collections import OrderedDict
 from functools import lru_cache, partial, wraps
 
 import falcon
-from falcon import HTTP_BAD_REQUEST
-
 import hug._empty as empty
 import hug.api
 import hug.output_format
 import hug.types as types
+from falcon import HTTP_BAD_REQUEST
 from hug import introspect
 from hug._async import asyncio_call
 from hug.exceptions import InvalidTypeData

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -22,10 +22,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import absolute_import
 
 import base64
-try:
-            import ujson as json_converter
-except ImportError:
-            import json as json_converter
 import mimetypes
 import os
 import re
@@ -38,9 +34,15 @@ from operator import itemgetter
 
 import falcon
 from falcon import HTTP_NOT_FOUND
-
 from hug import introspect
 from hug.format import camelcase, content_type
+
+try:  # pragma: no cover
+    import ujson as json_converter
+except ImportError:
+    import json as json_converter
+
+
 
 IMAGE_TYPES = ('png', 'jpg', 'bmp', 'eps', 'gif', 'im', 'jpeg', 'msp', 'pcx', 'ppm', 'spider', 'tiff', 'webp', 'xbm',
                'cur', 'dcx', 'fli', 'flc', 'gbr', 'gd', 'ico', 'icns', 'imt', 'iptc', 'naa', 'mcidas', 'mpo', 'pcd',

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -22,7 +22,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import absolute_import
 
 import base64
-import json as json_converter
+try:
+            import ujson as json_converter
+except ImportError:
+            import json as json_converter
 import mimetypes
 import os
 import re

--- a/hug/route.py
+++ b/hug/route.py
@@ -24,9 +24,8 @@ from __future__ import absolute_import
 from functools import partial
 from types import FunctionType, MethodType
 
-from falcon import HTTP_METHODS
-
 import hug.api
+from falcon import HTTP_METHODS
 from hug.routing import CLIRouter as cli
 from hug.routing import ExceptionRouter as exception
 from hug.routing import LocalRouter as local

--- a/hug/routing.py
+++ b/hug/routing.py
@@ -29,11 +29,10 @@ from functools import wraps
 from urllib.parse import urljoin
 
 import falcon
-from falcon import HTTP_METHODS
-
 import hug.api
 import hug.interface
 import hug.output_format
+from falcon import HTTP_METHODS
 from hug import introspect
 from hug.exceptions import InvalidTypeData
 

--- a/hug/test.py
+++ b/hug/test.py
@@ -22,10 +22,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import absolute_import
 
 import sys
-try:
-    import ujson as json
-except ImportError:
-    import json
 from functools import partial
 from io import BytesIO
 from unittest import mock
@@ -33,9 +29,15 @@ from urllib.parse import urlencode
 
 from falcon import HTTP_METHODS
 from falcon.testing import StartResponseMock, create_environ
-
 from hug import output_format
 from hug.api import API
+
+try:   # pragma: no cover
+    import ujson as json
+except ImportError:
+    import json
+
+
 
 
 def call(method, api_or_module, url, body='', headers=None, params=None, query_string='', scheme='http', **kwargs):

--- a/hug/test.py
+++ b/hug/test.py
@@ -21,8 +21,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
-import json
 import sys
+try:
+    import ujson as json
+except ImportError:
+    import json
 from functools import partial
 from io import BytesIO
 from unittest import mock

--- a/hug/types.py
+++ b/hug/types.py
@@ -23,8 +23,10 @@ from __future__ import absolute_import
 
 import uuid as native_uuid
 from decimal import Decimal
-from json import loads as load_json
-
+try:
+    from ujson import loads as load_json
+except ImportError:
+    from json import loads as load_json
 import hug._empty as empty
 from hug import introspect
 from hug.exceptions import InvalidTypeData

--- a/hug/types.py
+++ b/hug/types.py
@@ -23,13 +23,15 @@ from __future__ import absolute_import
 
 import uuid as native_uuid
 from decimal import Decimal
+
+import hug._empty as empty
+from hug import introspect
+from hug.exceptions import InvalidTypeData
+
 try:
     from ujson import loads as load_json
 except ImportError:
     from json import loads as load_json
-import hug._empty as empty
-from hug import introspect
-from hug.exceptions import InvalidTypeData
 
 
 class Type(object):

--- a/hug/use.py
+++ b/hug/use.py
@@ -28,9 +28,8 @@ from io import BytesIO
 from queue import Queue
 
 import falcon
-import requests
-
 import hug._empty as empty
+import requests
 from hug.api import API
 from hug.defaults import input_format
 from hug.format import parse_content_type

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,4 +1,5 @@
 -r common.txt
+ujson==1.35
 flake8==3.3.0
 isort==4.2.5
 marshmallow==2.13.4

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,6 +1,7 @@
 bumpversion==0.5.3
 Cython==0.25.2
 -r common.txt
+usjon==1.35
 flake8==3.3.0
 frosted==1.4.1
 ipython==5.3.0

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,9 @@ setup(name='hug',
       packages=['hug'],
       requires=['falcon', 'requests'],
       install_requires=['falcon==1.3.0', 'requests'],
+      extras_require = {
+          'ultrajson':  ["ujson"]
+      },
       cmdclass=cmdclass,
       ext_modules=ext_modules,
       keywords='Web, Python, Python3, Refactoring, REST, Framework, RPC',

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,9 +2,8 @@
 from collections import namedtuple
 from random import randint
 
-import pytest
-
 import hug
+import pytest
 
 Routers = namedtuple('Routers', ['http', 'local', 'cli'])
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,9 +19,8 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
-import pytest
-
 import hug
+import pytest
 
 api = hug.API(__name__)
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -19,7 +19,10 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
-import json
+try:
+    import ujson as json
+except ImportError:
+    import json
 import os
 import sys
 from unittest import mock

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -28,11 +28,10 @@ import sys
 from unittest import mock
 
 import falcon
+import hug
 import pytest
 import requests
 from falcon.testing import StartResponseMock, create_environ
-
-import hug
 from hug._async import coroutine
 
 from .constants import BASE_DIRECTORY

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -21,9 +21,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from base64 import b64encode
 
-import pytest
-
 import hug
+import pytest
 
 api = hug.API(__name__)
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -24,10 +24,9 @@ try:
 except ImportError:
     import json
 
+import hug
 from falcon import Request
 from falcon.testing import StartResponseMock, create_environ
-
-import hug
 
 api = hug.API(__name__)
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -19,7 +19,10 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
-import json
+try:
+    import ujson as json
+except ImportError:
+    import json
 
 from falcon import Request
 from falcon.testing import StartResponseMock, create_environ

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -19,9 +19,8 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
-import pytest
-
 import hug
+import pytest
 
 
 def test_invalid_type_data():

--- a/tests/test_input_format.py
+++ b/tests/test_input_format.py
@@ -23,9 +23,8 @@ import os
 from cgi import parse_header
 from io import BytesIO
 
-import requests
-
 import hug
+import requests
 
 from .constants import BASE_DIRECTORY
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -19,9 +19,8 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
-import pytest
-
 import hug
+import pytest
 
 
 @hug.http(('/namer', '/namer/{name}'), ('GET', 'POST'), versions=(None, 2))

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -17,10 +17,9 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
+import hug
 import pytest
 from falcon.request import SimpleCookie
-
-import hug
 from hug.exceptions import SessionNotFound
 from hug.middleware import CORSMiddleware, LogMiddleware, SessionMiddleware
 from hug.store import InMemoryStore

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -25,9 +25,8 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from io import BytesIO
 
-import pytest
-
 import hug
+import pytest
 
 from .constants import BASE_DIRECTORY
 

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -20,9 +20,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 """
 import falcon
-import pytest
-
 import hug.redirect
+import pytest
 
 
 def test_to():

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -20,7 +20,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 """
 import pytest
-
 from hug.exceptions import StoreKeyNotFound
 from hug.store import InMemoryStore
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -28,11 +28,10 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
-import pytest
-from marshmallow import Schema, fields
-
 import hug
+import pytest
 from hug.exceptions import InvalidTypeData
+from marshmallow import Schema, fields
 
 
 def test_type():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -19,7 +19,10 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 OTHER DEALINGS IN THE SOFTWARE.
 
 """
-import json
+try:
+    import ujson as json
+except ImportError:
+    import json
 import urllib
 from datetime import datetime
 from decimal import Decimal

--- a/tests/test_use.py
+++ b/tests/test_use.py
@@ -23,10 +23,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 import socket
 import struct
 
+import hug
 import pytest
 import requests
-
-import hug
 from hug import use
 
 


### PR DESCRIPTION
Added few lines to add ultrajson support. I our organization we are using hug to enable pico-micro-services that are basically json loaders & dumpers functions, which having support for an ultra fast json encoder/decoder makes the whole thing taking to the next level, as I cannot see any reason beyond using pypy to not use ujson in hug code base (not known incompatibilities or using any `ujson` lacking regular `json` API), I think that for CPython it's interesting to at least enable ultrajson for those who prefer it. Test are passing on CPython 3.6 locally.

I also added it as an extra, not mandatory:

```
# Install hug with ultrajson
pip install hug[ultrajson]
```
Let me see your thoughts about this :) 
PD: Not very used to travis+tox testing, so testing with and without ultrajson is kinda beyond my scope atm