### PR TITLE
Adds URL-encoded feature to *getting started* example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,35 @@ To run, from the command line type:
 hug -f happy_birthday.py
 ```
 
-You can access the example in your browser at: `localhost:8000/happy_birthday?name=hug&age=1`. Then check out the documentation for your API at `localhost:8000/documentation`
+You can access the example in your browser at:
+`localhost:8000/happy_birthday?name=hug&age=1`. Then check out the
+documentation for your API at `localhost:8000/documentation`
 
+Parameters can also be encoded in the URL (check
+out [`happy_birthday.py`](examples/happy_birthday.py) for the whole
+example).
 
+```py
+@hug.get('/greet/{event}')
+def greet(event: str):
+    """Greets appropriately (from http://blog.ketchum.com/how-to-write-10-common-holiday-greetings/)  """
+    greetings = "Happy"
+    if event == "Christmas":
+        greetings = "Merry"
+    if event == "Kwanzaa":
+        greetings = "Joyous"
+    if event == "wishes":
+        greetings = "Warm"
+
+    return "{greetings} {event}!".format(**locals())
+```
+
+Which, once you are running the server as above, you can use this way:
+
+```
+curl http://localhost:8000/greet/wishes
+"Warm wishes!"
+```
 
 Versioning with hug
 ===================

--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ def math(number_1:int, number_2:int): #The :int after both arguments is the Type
     return number_1 + number_2
 ```
 
-Type annotations also feed into hug's automatic documentation generation to let users of your API know what data to supply.
+Type annotations also feed into `hug`'s automatic documentation
+generation to let users of your API know what data to supply. 
 
 
 **Directives** functions that get executed with the request / response data based on being requested as an argument in your api_function.

--- a/examples/happy_birthday.py
+++ b/examples/happy_birthday.py
@@ -6,3 +6,16 @@ import hug
 def happy_birthday(name, age: hug.types.number):
     """Says happy birthday to a user"""
     return "Happy {age} Birthday {name}!".format(**locals())
+
+@hug.get('/greet/{event}')
+def greet(event: str):
+    """Greets appropriately (from http://blog.ketchum.com/how-to-write-10-common-holiday-greetings/)  """
+    greetings = "Happy"
+    if event == "Christmas":
+        greetings = "Merry"
+    if event == "Kwanzaa":
+        greetings = "Joyous"
+    if event == "wishes":
+        greetings = "Warm"
+
+    return "{greetings} {event}!".format(**locals())

--- a/examples/test_happy_birthday.py
+++ b/examples/test_happy_birthday.py
@@ -6,3 +6,11 @@ def tests_happy_birthday():
     response = hug.test.get(happy_birthday, 'happy_birthday', {'name': 'Timothy', 'age': 25})
     assert response.status == HTTP_200
     assert response.data is not None
+
+def tests_season_greetings():
+    response = hug.test.get(happy_birthday, 'greet/Christmas')
+    assert response.status == HTTP_200
+    assert response.data is not None
+    assert str(response.data) == "Merry Christmas!"
+    response = hug.test.get(happy_birthday, 'greet/holidays')
+    assert str(response.data) == "Happy holidays!"


### PR DESCRIPTION
I was used to that way of using REST frameworks, and I didn't find documentation for it. Once again, searching among code I found an example that did use it, so I have added a function to the example, tested it and added a reference to it in the documentation. There are also minor reformatting changes in the README.md file
Once again, thanks for your great work. My intention for this is to use it as support for a web services with Python tutorial which I'm delivering next Tuesday. 