### PR TITLE
Feature: Support ujson if installed

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -21,7 +21,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
-import json
 import sys
 from collections import OrderedDict, namedtuple
 from distutils.util import strtobool
@@ -31,13 +30,13 @@ from types import ModuleType
 from wsgiref.simple_server import make_server
 
 import falcon
-from falcon import HTTP_METHODS
-
 import hug.defaults
 import hug.output_format
+from falcon import HTTP_METHODS
 from hug import introspect
 from hug._async import asyncio, ensure_future
 from hug._version import current
+from hug.json_module import json
 
 
 INTRO = """

--- a/hug/input_format.py
+++ b/hug/input_format.py
@@ -21,14 +21,13 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
-import json as json_converter
 import re
 from cgi import parse_multipart
 from urllib.parse import parse_qs as urlencoded_converter
 
 from falcon.util.uri import parse_query_string
-
 from hug.format import content_type, underscore
+from hug.json_module import json as json_converter
 
 
 @content_type('text/plain')

--- a/hug/json_module.py
+++ b/hug/json_module.py
@@ -15,7 +15,11 @@ try:
                 kwargs.pop('default', None)
                 kwargs.pop('separators', None)
                 kwargs.update(escape_forward_slashes=False)
-                return self._dumps(*args, **kwargs)
+                try:  # pragma: no cover
+                    return self._dumps(*args, **kwargs)
+                except Exception as exc:
+                    raise TypeError("Type[ujson] is not Serializable", exc)
+
         json.dumps = dumps_proxy()
     else:
         import json

--- a/hug/json_module.py
+++ b/hug/json_module.py
@@ -4,6 +4,18 @@ HUG_USE_UJSON = bool(os.environ.get('HUG_USE_UJSON', 1))
 try:
     if HUG_USE_UJSON:
         import ujson as json
+
+        class dumps_proxy:
+            """Proxies the call so non supported kwargs are skipped
+            and it enables escape_forward_slashes to simulate built-in json
+            """
+            _dumps = json.dumps
+
+            def __call__(self, *args, **kwargs):
+                kwargs.pop('default', None)
+                kwargs.update(escape_forward_slashes=False)
+                return self._dumps(*args, **kwargs)
+        json = dumps_proxy()
     else:
         import json
 except ImportError:

--- a/hug/json_module.py
+++ b/hug/json_module.py
@@ -1,7 +1,7 @@
 import os
 
 HUG_USE_UJSON = bool(os.environ.get('HUG_USE_UJSON', 1))
-try:
+try:  # pragma: no cover
     if HUG_USE_UJSON:
         import ujson as json
 
@@ -15,7 +15,7 @@ try:
                 kwargs.pop('default', None)
                 kwargs.pop('separators', None)
                 kwargs.update(escape_forward_slashes=False)
-                try:  # pragma: no cover
+                try:
                     return self._dumps(*args, **kwargs)
                 except Exception as exc:
                     raise TypeError("Type[ujson] is not Serializable", exc)
@@ -23,5 +23,5 @@ try:
         json.dumps = dumps_proxy()
     else:
         import json
-except ImportError:
+except ImportError:  # pragma: no cover
     import json

--- a/hug/json_module.py
+++ b/hug/json_module.py
@@ -1,0 +1,10 @@
+import os
+
+HUG_USE_UJSON = bool(os.environ.get('HUG_USE_UJSON', 1))
+try:
+    if HUG_USE_UJSON:
+        import ujson as json
+    else:
+        import json
+except ImportError:
+    import json

--- a/hug/json_module.py
+++ b/hug/json_module.py
@@ -13,6 +13,7 @@ try:
 
             def __call__(self, *args, **kwargs):
                 kwargs.pop('default', None)
+                kwargs.pop('separators', None)
                 kwargs.update(escape_forward_slashes=False)
                 return self._dumps(*args, **kwargs)
         json.dumps = dumps_proxy()

--- a/hug/json_module.py
+++ b/hug/json_module.py
@@ -15,7 +15,7 @@ try:
                 kwargs.pop('default', None)
                 kwargs.update(escape_forward_slashes=False)
                 return self._dumps(*args, **kwargs)
-        json = dumps_proxy()
+        json.dumps = dumps_proxy()
     else:
         import json
 except ImportError:

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -22,7 +22,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 from __future__ import absolute_import
 
 import base64
-import json as json_converter
 import mimetypes
 import os
 import re
@@ -35,9 +34,9 @@ from operator import itemgetter
 
 import falcon
 from falcon import HTTP_NOT_FOUND
-
 from hug import introspect
 from hug.format import camelcase, content_type
+from hug.json_module import json as json_converter
 
 IMAGE_TYPES = ('png', 'jpg', 'bmp', 'eps', 'gif', 'im', 'jpeg', 'msp', 'pcx', 'ppm', 'spider', 'tiff', 'webp', 'xbm',
                'cur', 'dcx', 'fli', 'flc', 'gbr', 'gd', 'ico', 'icns', 'imt', 'iptc', 'naa', 'mcidas', 'mpo', 'pcd',

--- a/hug/test.py
+++ b/hug/test.py
@@ -21,7 +21,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 from __future__ import absolute_import
 
-import json
 import sys
 from functools import partial
 from io import BytesIO
@@ -30,9 +29,9 @@ from urllib.parse import urlencode
 
 from falcon import HTTP_METHODS
 from falcon.testing import StartResponseMock, create_environ
-
 from hug import output_format
 from hug.api import API
+from hug.json_module import json
 
 
 def call(method, api_or_module, url, body='', headers=None, params=None, query_string='', scheme='http', **kwargs):

--- a/hug/types.py
+++ b/hug/types.py
@@ -23,11 +23,11 @@ from __future__ import absolute_import
 
 import uuid as native_uuid
 from decimal import Decimal
-from json import loads as load_json
 
 import hug._empty as empty
 from hug import introspect
 from hug.exceptions import InvalidTypeData
+from hug.json_module import json as json_converter
 
 
 class Type(object):
@@ -241,7 +241,7 @@ class JSON(Type):
     def __call__(self, value):
         if type(value) in (str, bytes):
             try:
-                return load_json(value)
+                return json_converter.loads(value)
             except Exception:
                 raise ValueError('Incorrectly formatted JSON provided')
         else:

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -12,3 +12,4 @@ tox==2.7.0
 wheel==0.29.0
 pytest-xdist==1.14.0
 marshmallow==2.6.0
+ujson==1.35


### PR DESCRIPTION
If installed but no wish to use it set `HUG_USE_UJSON=0` environmental variable. This is for the sake of people not wanting to use `ujson` even when installed in the python environment. 

This would increase the performance dramatically for those microservices that are basically _JSON loaders/dumpers endpoints_.
 