### PR TITLE
fixes the base_url bug in CORSMiddleware

### DIFF
--- a/hug/middleware.py
+++ b/hug/middleware.py
@@ -126,8 +126,8 @@ class CORSMiddleware(object):
         if reqpath not in routes:
             for route in routes:  # replace params in route with regex
                 reqpath = re.sub('^(/v\d*/?)', '/', reqpath)
-                base_url = getattr(self.api, 'base_url', '')
-                reqpath = reqpath.lstrip('/{}'.format(base_url)) if base_url else reqpath
+                base_url = getattr(self.api.http, 'base_url', '')
+                reqpath = reqpath.replace(base_url, '', 1) if base_url else reqpath
                 if re.match(re.sub(r'/{[^{}]+}', '/\w+', route) + '$', reqpath):
                     return route
 


### PR DESCRIPTION
```
app = hug.API(__name__)
app.http.base_url = '/api'
app.http.add_middleware(hug.middleware.CORSMiddleware(app, max_age=7))

```
when the base_url is '/api', request the url is '/api/auth/token' , there is an exception:
```
 File "/Users/ford/miniconda3/envs/python3/lib/python3.6/site-packages/hug/middleware.py", line 145, in <genexpr>
    for method, _ in routes[self.match_route(request.path)].items()
KeyError: '/api/auth/token'
```
