### PR TITLE
Return docs for marshmallow schema instead of for dump method

### DIFF
--- a/hug/interface.py
+++ b/hug/interface.py
@@ -166,8 +166,8 @@ class Interface(object):
             self.transform = self.interface.transform
 
         if hasattr(self.transform, 'dump'):
-            self.transform = self.transform.dump
             self.output_doc = self.transform.__doc__
+            self.transform = self.transform.dump
         elif self.transform or self.interface.transform:
             output_doc = (self.transform or self.interface.transform)
             self.output_doc = output_doc if type(output_doc) is str else output_doc.__doc__

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -25,6 +25,7 @@ from falcon import Request
 from falcon.testing import StartResponseMock, create_environ
 
 import hug
+import marshmallow
 
 api = hug.API(__name__)
 
@@ -147,3 +148,17 @@ def test_basic_documentation():
     assert 'versions' in documentation
     assert '/echo' in documentation['handlers']
     assert '/test' not in documentation['handlers']
+
+
+def test_marshallow_return_type_documentation():
+
+    class Returns(marshmallow.Schema):
+        "Return docs"
+
+    @hug.post()
+    def test() -> Returns():
+        pass
+
+    doc = api.http.documentation()
+
+    assert doc['handlers']['/test']['POST']['outputs']['type'] == "Return docs"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -156,9 +156,9 @@ def test_marshallow_return_type_documentation():
         "Return docs"
 
     @hug.post()
-    def test() -> Returns():
+    def testret() -> Returns():
         pass
 
     doc = api.http.documentation()
 
-    assert doc['handlers']['/test']['POST']['outputs']['type'] == "Return docs"
+    assert doc['handlers']['/testret']['POST']['outputs']['type'] == "Return docs"


### PR DESCRIPTION
This fixes #657 but it needs some examination. I'm not sure why the code originally was looking at the `dump` docstring and what functionality may be lost because of this.