### PR TITLE
Handle marshmallow return type schemas similarly to input types

### DIFF
--- a/hug/interface.py
+++ b/hug/interface.py
@@ -38,7 +38,7 @@ from hug import introspect
 from hug._async import asyncio_call
 from hug.exceptions import InvalidTypeData
 from hug.format import parse_content_type
-from hug.types import MarshmallowSchema, Multiple, OneOf, SmartBoolean, Text, text
+from hug.types import MarshmallowInputSchema, MarshmallowReturnSchema, Multiple, OneOf, SmartBoolean, Text, text
 
 
 class Interfaces(object):
@@ -88,7 +88,7 @@ class Interfaces(object):
             if hasattr(transformer, 'from_string'):
                 transformer = transformer.from_string
             elif hasattr(transformer, 'load'):
-                transformer = MarshmallowSchema(transformer)
+                transformer = MarshmallowInputSchema(transformer)
             elif hasattr(transformer, 'deserialize'):
                 transformer = transformer.deserialize
 
@@ -166,7 +166,7 @@ class Interface(object):
             self.transform = self.interface.transform
 
         if hasattr(self.transform, 'dump'):
-            self.transform = self.transform.dump
+            self.transform = MarshmallowReturnSchema(self.transform)
             self.output_doc = self.transform.__doc__
         elif self.transform or self.interface.transform:
             output_doc = (self.transform or self.interface.transform)

--- a/hug/types.py
+++ b/hug/types.py
@@ -596,7 +596,6 @@ class MarshmallowReturnSchema(Type):
         value, errors = self.schema.dump(value)
         if errors:
             raise InvalidTypeData('Invalid {0} passed in'.format(self.schema.__class__.__name__), errors)
-        print(f'returning {value}')
         return value
 
 

--- a/hug/types.py
+++ b/hug/types.py
@@ -562,8 +562,8 @@ class Schema(object, metaclass=NewTypeMeta):
 json = JSON()
 
 
-class MarshmallowSchema(Type):
-    """Allows using a Marshmallow Schema directly in a hug type annotation"""
+class MarshmallowInputSchema(Type):
+    """Allows using a Marshmallow Schema directly in a hug input type annotation"""
     __slots__ = ("schema")
 
     def __init__(self, schema):
@@ -579,6 +579,26 @@ class MarshmallowSchema(Type):
         if errors:
             raise InvalidTypeData('Invalid {0} passed in'.format(self.schema.__class__.__name__), errors)
         return value
+
+
+class MarshmallowReturnSchema(Type):
+    """Allows using a Marshmallow Schema directly in a hug return type annotation"""
+    __slots__ = ("schema", )
+
+    def __init__(self, schema):
+        self.schema = schema
+
+    @property
+    def __doc__(self):
+        return self.schema.__doc__ or self.schema.__class__.__name__
+
+    def __call__(self, value):
+        value, errors = self.schema.dump(value)
+        if errors:
+            raise InvalidTypeData('Invalid {0} passed in'.format(self.schema.__class__.__name__), errors)
+        print(f'returning {value}')
+        return value
+
 
 
 multiple = Multiple()

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -25,6 +25,7 @@ from falcon import Request
 from falcon.testing import StartResponseMock, create_environ
 
 import hug
+import marshmallow
 
 api = hug.API(__name__)
 
@@ -147,3 +148,17 @@ def test_basic_documentation():
     assert 'versions' in documentation
     assert '/echo' in documentation['handlers']
     assert '/test' not in documentation['handlers']
+
+
+def test_marshallow_return_type_documentation():
+
+    class Returns(marshmallow.Schema):
+        "Return docs"
+
+    @hug.post()
+    def test() -> Returns():
+        pass
+
+    doc = api.http.documentation()
+
+    assert doc['handlers']['/test']['POST']['outputs']['type'] == "Return docs"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -150,15 +150,15 @@ def test_basic_documentation():
     assert '/test' not in documentation['handlers']
 
 
-def test_marshallow_return_type_documentation():
+def test_marshmallow_return_type_documentation():
 
     class Returns(marshmallow.Schema):
         "Return docs"
 
     @hug.post()
-    def test() -> Returns():
+    def marshtest() -> Returns():
         pass
 
     doc = api.http.documentation()
 
-    assert doc['handlers']['/test']['POST']['outputs']['type'] == "Return docs"
+    assert doc['handlers']['/marshtest']['POST']['outputs']['type'] == "Return docs"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -359,14 +359,20 @@ def test_schema_type():
 def test_marshmallow_schema():
     """Test hug's marshmallow schema support"""
     class UserSchema(Schema):
-        name = fields.Str()
+        name = fields.Int()
 
-    schema_type = hug.types.MarshmallowSchema(UserSchema())
-    assert schema_type({"name": "test"}, {}) == {"name": "test"}
-    assert schema_type("""{"name": "test"}""", {}) == {"name": "test"}
+    schema_type = hug.types.MarshmallowInputSchema(UserSchema())
+    assert schema_type({"name": 23}, {}) == {"name": 23}
+    assert schema_type("""{"name": 23}""", {}) == {"name": 23}
     assert schema_type.__doc__ == 'UserSchema'
     with pytest.raises(InvalidTypeData):
-        schema_type({"name": 1}, {})
+        schema_type({"name": "test"}, {})
+
+    schema_type = hug.types.MarshmallowReturnSchema(UserSchema())
+    assert schema_type({"name": 23}) == {"name": 23}
+    assert schema_type.__doc__ == 'UserSchema'
+    with pytest.raises(InvalidTypeData):
+        schema_type({"name": "test"})
 
 
 def test_create_type():


### PR DESCRIPTION
This:
 - makes route functions return just the data they are supposed to instead of
a tuple containing the data (issue #627).
- uses the docstring for the return schema type instead of for the `dump`
method (issue #657).