### PR TITLE
Transform context

### DIFF
--- a/examples/sqlalchemy_example/demo/api.py
+++ b/examples/sqlalchemy_example/demo/api.py
@@ -3,7 +3,7 @@ import hug
 from demo.authentication import basic_authentication
 from demo.directives import SqlalchemySession
 from demo.models import TestUser, TestModel
-from demo.validation import CreateUserSchema, unique_username
+from demo.validation import CreateUserSchema, DumpSchema, unique_username
 
 
 @hug.post('/create_user2', requires=basic_authentication)
@@ -47,6 +47,16 @@ def make_simple_query(db: SqlalchemySession):
         db.add(test_model)
         db.flush()
     return " ".join([obj.name for obj in db.query(TestModel).all()])
+
+
+@hug.get('/hello2')
+def transform_example(db: SqlalchemySession) -> DumpSchema():
+    for word in ["hello", "world", ":)"]:
+        test_model = TestModel()
+        test_model.name = word
+        db.add(test_model)
+        db.flush()
+    return dict(users=db.query(TestModel).all())
 
 
 @hug.get('/protected', requires=basic_authentication)

--- a/examples/sqlalchemy_example/demo/validation.py
+++ b/examples/sqlalchemy_example/demo/validation.py
@@ -2,9 +2,10 @@ import hug
 from marshmallow import fields
 from marshmallow.decorators import validates_schema
 from marshmallow.schema import Schema
+from marshmallow_sqlalchemy import ModelSchema
 
 from demo.context import SqlalchemyContext
-from demo.models import TestUser
+from demo.models import TestUser, TestModel
 
 
 @hug.type(extend=hug.types.text, chain=True, accept_context=True)
@@ -30,3 +31,18 @@ class CreateUserSchema(Schema):
             ).exists()
         ).scalar():
             raise ValueError('User with a username {0} already exists.'.format(data['username']))
+
+
+class DumpUserSchema(ModelSchema):
+
+    @property
+    def session(self):
+        return self.context.db
+
+    class Meta:
+        model = TestModel
+        fields = ('name',)
+
+
+class DumpSchema(Schema):
+    users = fields.Nested(DumpUserSchema, many=True)

--- a/examples/sqlalchemy_example/requirements.txt
+++ b/examples/sqlalchemy_example/requirements.txt
@@ -1,3 +1,4 @@
-hug
+git+git://github.com/timothycrosley/hug@develop#egg=hug
 sqlalchemy
 marshmallow
+marshmallow-sqlalchemy

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -355,10 +355,7 @@ class Local(Interface):
             if self.transform:
                 if hasattr(self.transform, 'context'):
                     self.transform.context = context
-                if hasattr(self.transform, 'dump'):
-                    result = self.transform.dump(result)
-                else:
-                    result = self.transform(result)
+                result = self.transform(result)
         except Exception as exception:
             self.cleanup_parameters(kwargs, exception=exception)
             self.api.delete_context(context, exception=exception)
@@ -468,10 +465,7 @@ class CLI(Interface):
         if self.transform:
             if hasattr(self.transform, 'context'):
                 self.transform.context = context
-            if hasattr(self.transform, 'dump'):
-                data = self.transform.dump(data)
-            else:
-                data = self.transform(data)
+            data = self.transform(data)
         if hasattr(data, 'read'):
             data = data.read().decode('utf8')
         if data is not None:
@@ -646,8 +640,6 @@ class HTTP(Interface):
         transform = self.transform
         if hasattr(transform, 'context'):
             self.transform.context = context
-        if hasattr(transform, 'dump'):
-            transform = transform.dump
         """Runs the transforms specified on this endpoint with the provided data, returning the data modified"""
         if transform and not (isinstance(transform, type) and isinstance(data, transform)):
             if self._params_for_transform:

--- a/hug/interface.py
+++ b/hug/interface.py
@@ -165,8 +165,7 @@ class Interface(object):
         if self.transform is None and not isinstance(self.interface.transform, (str, type(None))):
             self.transform = self.interface.transform
 
-        if hasattr(self.transform, 'dump'):
-            self.transform = self.transform.dump
+        if hasattr(self.transform, 'context') or hasattr(self.transform, 'dump'):
             self.output_doc = self.transform.__doc__
         elif self.transform or self.interface.transform:
             output_doc = (self.transform or self.interface.transform)
@@ -352,14 +351,19 @@ class Local(Interface):
             self._rewrite_params(kwargs)
         try:
             result = self.interface(**kwargs)
-            self.cleanup_parameters(kwargs)
-            self.api.delete_context(context)
+            if self.transform:
+                if hasattr(self.transform, 'context'):
+                    self.transform.context = context
+                if hasattr(self.transform, 'dump'):
+                    result = self.transform.dump(result)
+                else:
+                    result = self.transform(result)
         except Exception as exception:
             self.cleanup_parameters(kwargs, exception=exception)
             self.api.delete_context(context, exception=exception)
             raise exception
-        if self.transform:
-            result = self.transform(result)
+        self.cleanup_parameters(kwargs)
+        self.api.delete_context(context)
         return self.outputs(result) if self.outputs else result
 
 
@@ -458,10 +462,15 @@ class CLI(Interface):
     def outputs(self, outputs):
         self._outputs = outputs
 
-    def output(self, data):
+    def output(self, data, context):
         """Outputs the provided data using the transformations and output format specified for this CLI endpoint"""
         if self.transform:
-            data = self.transform(data)
+            if hasattr(self.transform, 'context'):
+                self.transform.context = context
+            if hasattr(self.transform, 'dump'):
+                data = self.transform.dump(data)
+            else:
+                data = self.transform(data)
         if hasattr(data, 'read'):
             data = data.read().decode('utf8')
         if data is not None:
@@ -485,7 +494,7 @@ class CLI(Interface):
             conclusion = requirement(request=sys.argv, module=self.api.module, context=context)
             if conclusion and conclusion is not True:
                 self.api.delete_context(context, lacks_requirement=conclusion)
-                return self.output(conclusion)
+                return self.output(conclusion, context)
 
         if self.interface.is_method:
             self.parser.prog = "%s %s" % (self.api.module.__name__, self.interface.name)
@@ -509,7 +518,7 @@ class CLI(Interface):
             errors = self.validate_function(pass_to_function)
             if errors:
                 self.api.delete_context(context, errors=errors)
-                return self.output(errors)
+                return self.output(errors, context)
 
         args = None
         if self.additional_options:
@@ -538,16 +547,16 @@ class CLI(Interface):
 
         try:
             if args:
-                result = self.interface(*args, **pass_to_function)
+                result = self.output(self.interface(*args, **pass_to_function), context)
             else:
-                result = self.interface(**pass_to_function)
-            self.cleanup_parameters(pass_to_function)
-            self.api.delete_context(context)
+                result = self.output(self.interface(**pass_to_function), context)
         except Exception as exception:
             self.cleanup_parameters(pass_to_function, exception=exception)
             self.api.delete_context(context, exception=exception)
             raise exception
-        return self.output(result)
+        self.cleanup_parameters(pass_to_function)
+        self.api.delete_context(context)
+        return result
 
 
 class HTTP(Interface):
@@ -632,13 +641,18 @@ class HTTP(Interface):
     def outputs(self, outputs):
         self._outputs = outputs
 
-    def transform_data(self, data, request=None, response=None):
+    def transform_data(self, data, request=None, response=None, context=None):
+        transform = self.transform
+        if hasattr(transform, 'context'):
+            self.transform.context = context
+        if hasattr(transform, 'dump'):
+            transform = transform.dump
         """Runs the transforms specified on this endpoint with the provided data, returning the data modified"""
-        if self.transform and not (isinstance(self.transform, type) and isinstance(data, self.transform)):
+        if transform and not (isinstance(transform, type) and isinstance(data, transform)):
             if self._params_for_transform:
-                return self.transform(data, **self._arguments(self._params_for_transform, request, response))
+                return transform(data, **self._arguments(self._params_for_transform, request, response))
             else:
-                return self.transform(data)
+                return transform(data)
         return data
 
     def content_type(self, request=None, response=None):
@@ -695,7 +709,7 @@ class HTTP(Interface):
 
         return self.interface(**parameters)
 
-    def render_content(self, content, request, response, **kwargs):
+    def render_content(self, content, context, request, response, **kwargs):
         if hasattr(content, 'interface') and (content.interface is True or hasattr(content.interface, 'http')):
             if content.interface is True:
                 content(request, response, api_version=None, **kwargs)
@@ -703,7 +717,7 @@ class HTTP(Interface):
                 content.interface.http(request, response, api_version=None, **kwargs)
             return
 
-        content = self.transform_data(content, request, response)
+        content = self.transform_data(content, request, response, context)
         content = self.outputs(content, **self._arguments(self._params_for_outputs, request, response))
         if hasattr(content, 'read'):
             size = None
@@ -756,9 +770,7 @@ class HTTP(Interface):
                 self.api.delete_context(context, errors=errors)
                 return self.render_errors(errors, request, response)
 
-            self.render_content(self.call_function(input_parameters), request, response, **kwargs)
-            self.cleanup_parameters(input_parameters)
-            self.api.delete_context(context)
+            self.render_content(self.call_function(input_parameters), context, request, response, **kwargs)
         except falcon.HTTPNotFound as exception:
             self.cleanup_parameters(input_parameters, exception=exception)
             self.api.delete_context(context, exception=exception)
@@ -786,6 +798,8 @@ class HTTP(Interface):
             self.cleanup_parameters(input_parameters, exception=exception)
             self.api.delete_context(context, exception=exception)
             raise exception
+        self.cleanup_parameters(input_parameters)
+        self.api.delete_context(context)
 
     def documentation(self, add_to=None, version=None, prefix="", base_url="", url=""):
         """Returns the documentation specific to an HTTP interface"""

--- a/hug/use.py
+++ b/hug/use.py
@@ -149,7 +149,7 @@ class Local(Service):
         if errors:
             interface.render_errors(errors, request, response)
         else:
-            interface.render_content(interface.call_function(params), request, response)
+            interface.render_content(interface.call_function(params), context, request, response)
 
         data = BytesIO(response.data)
         content_type, content_params = parse_content_type(response._headers.get('content-type', ''))


### PR DESCRIPTION
While making the context I was not aware of the transform functionality in hug. It is awesome and can be used along with marshmallow-sqlalchemy. After merging this PR marshmallow-code/marshmallow-sqlalchemy#129, you can use it like in the example (full working example in examples/sqlalchemy_example):

```python
class DumpUserSchema(ModelSchema):

    @property
    def session(self):
        return self.context.db

    class Meta:
        model = TestModel
        fields = ('name',)


class DumpSchema(Schema):
    users = fields.Nested(DumpUserSchema, many=True)


@hug.get('/hello2')
def transform_example(db: SqlalchemySession) -> DumpSchema():
    for word in ["hello", "world", ":)"]:
        test_model = TestModel()
        test_model.name = word
        db.add(test_model)
        db.flush()
    return dict(users=db.query(TestModel).all())
```