### PR TITLE
Fixed problem with hug.types.json

### DIFF
--- a/hug/types.py
+++ b/hug/types.py
@@ -314,6 +314,13 @@ class JSON(Type):
                 return json_converter.loads(value)
             except Exception:
                 raise ValueError('Incorrectly formatted JSON provided')
+        if type(value) is list:
+            # If Falcon is set to comma-separate entries, this segment joins them again.
+            try:
+                fixed_value = ",".join(value)
+                return json_converter.loads(fixed_value)
+            except Exception:
+                raise ValueError('Incorrectly formatted JSON provided')
         else:
             return value
 


### PR DESCRIPTION
This is not the perfect solution to #685 but it does allow for handling Falcon's splitting of comma-separated entries in a json request query parameter. A better solution would be allow for setting Falcon's RequestOptions somewhere in Hug. However, I have not been able to determine how to do this. Proposals are welcome :)