### PR TITLE
Correct base type inheritance example

### DIFF
--- a/documentation/TYPE_ANNOTATIONS.md
+++ b/documentation/TYPE_ANNOTATIONS.md
@@ -54,12 +54,12 @@ The most obvious way to extend a hug type is to simply inherit from the base typ
     import hug
 
 
-    class TheAnswer(hug.types.number):
+    class TheAnswer(hug.types.Text):
         """My new documentation"""
 
         def __call__(self, value):
             value = super().__call__(value)
-            if value != 42:
+            if value != 'fourty-two':
                 raise ValueError('Value is not the answer to everything.')
             return value
 


### PR DESCRIPTION
Subclassing `hug.types.number` doesn't work. Neither does `hug.types.text`, since `text` is an object of the `hug.types.Text` class.

I changed the example to subclass `hug.types.Text`.

Maybe it should be pointed out that subclassing actually works only for the types which are explicitly defined as classes in `hug.types`, and that `number`, `float_number`, `decimal`, `boolean` and `uuid` are defined using helpers which make simple subclassing impossible.