### PR TITLE
Add support for common numpy types

### DIFF
--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -103,7 +103,7 @@ if numpy:
     def numpy_integerable(item):
         return int(item)
 
-    @json_convert(numpy.float)
+    @json_convert(float, numpy.floating)
     def numpy_floatable(item):
         return float(item)
 

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -95,7 +95,7 @@ if numpy:
     def numpy_listable(item):
         return item.tolist()
 
-    @json_convert(numpy.str)
+    @json_convert(str, numpy.character)
     def numpy_stringable(item):
         return str(item)
 

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -95,9 +95,13 @@ if numpy:
     def numpy_listable(item):
         return item.tolist()
 
-    @json_convert(str, numpy.character)
+    @json_convert(str, numpy.unicode_)
     def numpy_stringable(item):
         return str(item)
+
+    @json_convert(numpy.bytes_)
+    def numpy_byte_decodeable(item):
+        return item.decode()
 
     @json_convert(numpy.bool_)
     def numpy_boolable(item):

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -91,13 +91,17 @@ def json_convert(*kinds):
 
 
 if numpy:
-    @json_convert(numpy.ndarray, numpy.int_)
+    @json_convert(numpy.ndarray)
     def numpy_listable(item):
         return item.tolist()
 
     @json_convert(numpy.str)
     def numpy_stringable(item):
         return str(item)
+
+    @json_convert(numpy.int_)
+    def numpy_integerable(item):
+        return int(item)
 
     @json_convert(numpy.float)
     def numpy_floatable(item):

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -99,7 +99,7 @@ if numpy:
     def numpy_stringable(item):
         return str(item)
 
-    @json_convert(numpy.int_)
+    @json_convert(numpy.integer)
     def numpy_integerable(item):
         return int(item)
 

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -99,6 +99,10 @@ if numpy:
     def numpy_stringable(item):
         return str(item)
 
+    @json_convert(numpy.bool_)
+    def numpy_boolable(item):
+        return bool(item)
+
     @json_convert(numpy.integer)
     def numpy_integerable(item):
         return int(item)

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -325,7 +325,8 @@ def test_json_converter_numpy_types():
     np_int_types = [numpy.int_, numpy.byte, numpy.ubyte, numpy.intc, numpy.uintc, numpy.intp, numpy.uintp, numpy.int8,
                     numpy.uint8, numpy.int16, numpy.uint16, numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
                     numpy.longlong, numpy.ulonglong, numpy.short, numpy.ushort]
-    np_float_types = [numpy.float_, numpy.float32, numpy.float64, numpy.float128]
+    np_float_types = [numpy.float_, numpy.float32, numpy.float64, numpy.half, numpy.single,
+                      numpy.longfloat]
     np_unicode_types = [numpy.unicode_]
     np_bytes_types = [numpy.bytes_]
 

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -309,10 +309,12 @@ def test_prefix():
 
 def test_json_converter_numpy_types():
     """Ensure that numpy-specific data types (array, int, float) are properly supported in JSON output."""
+    ex_int = numpy.int_(9)
     ex_np_array = numpy.array([1, 2, 3, 4, 5])
     ex_np_int_array = numpy.int_([5, 4, 3])
     ex_np_float = numpy.float(1.0)
 
+    assert 9 is hug.output_format._json_converter(ex_int)
     assert [1, 2, 3, 4, 5] == hug.output_format._json_converter(ex_np_array)
     assert [5, 4, 3] == hug.output_format._json_converter(ex_np_int_array)
     assert 1.0 == hug.output_format._json_converter(ex_np_float)

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -318,3 +318,19 @@ def test_json_converter_numpy_types():
     assert [1, 2, 3, 4, 5] == hug.output_format._json_converter(ex_np_array)
     assert [5, 4, 3] == hug.output_format._json_converter(ex_np_int_array)
     assert .5 == hug.output_format._json_converter(ex_np_float)
+
+    np_bool_types = [numpy.bool_, numpy.bool8]
+    np_int_types = [numpy.int_, numpy.byte, numpy.ubyte, numpy.intc, numpy.uintc, numpy.intp, numpy.uintp, numpy.int8,
+                    numpy.uint8, numpy.int16, numpy.uint16, numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
+                    numpy.longlong, numpy.ulonglong, numpy.short, numpy.ushort]
+    np_float_types = [numpy.float_, numpy.float32, numpy.float64, numpy.float128]
+    np_str_types = [numpy.bytes_, numpy.str, numpy.str_, numpy.string_, numpy.unicode_]
+
+    for np_type in np_bool_types:
+        assert True == hug.output_format._json_converter(np_type(True))
+    for np_type in np_int_types:
+        assert 1 is hug.output_format._json_converter(np_type(1))
+    for np_type in np_float_types:
+        assert .5 == hug.output_format._json_converter(np_type(.5))
+    for np_type in np_str_types:
+        assert 'a' is hug.output_format._json_converter(np_type('a'))

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -319,6 +319,8 @@ def test_json_converter_numpy_types():
     assert [5, 4, 3] == hug.output_format._json_converter(ex_np_int_array)
     assert .5 == hug.output_format._json_converter(ex_np_float)
 
+    # Some type names are merely shorthands.
+    # The following shorthands for built-in types are excluded: numpy.bool, numpy.int, numpy.float.
     np_bool_types = [numpy.bool_, numpy.bool8]
     np_int_types = [numpy.int_, numpy.byte, numpy.ubyte, numpy.intc, numpy.uintc, numpy.intp, numpy.uintp, numpy.int8,
                     numpy.uint8, numpy.int16, numpy.uint16, numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -312,9 +312,9 @@ def test_json_converter_numpy_types():
     ex_int = numpy.int_(9)
     ex_np_array = numpy.array([1, 2, 3, 4, 5])
     ex_np_int_array = numpy.int_([5, 4, 3])
-    ex_np_float = numpy.float(1.0)
+    ex_np_float = numpy.float(.5)
 
     assert 9 is hug.output_format._json_converter(ex_int)
     assert [1, 2, 3, 4, 5] == hug.output_format._json_converter(ex_np_array)
     assert [5, 4, 3] == hug.output_format._json_converter(ex_np_int_array)
-    assert 1.0 == hug.output_format._json_converter(ex_np_float)
+    assert .5 == hug.output_format._json_converter(ex_np_float)

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -326,7 +326,8 @@ def test_json_converter_numpy_types():
                     numpy.uint8, numpy.int16, numpy.uint16, numpy.int32, numpy.uint32, numpy.int64, numpy.uint64,
                     numpy.longlong, numpy.ulonglong, numpy.short, numpy.ushort]
     np_float_types = [numpy.float_, numpy.float32, numpy.float64, numpy.float128]
-    np_str_types = [numpy.bytes_, numpy.str, numpy.str_, numpy.string_, numpy.unicode_]
+    np_unicode_types = [numpy.unicode_]
+    np_bytes_types = [numpy.bytes_]
 
     for np_type in np_bool_types:
         assert True == hug.output_format._json_converter(np_type(True))
@@ -334,8 +335,10 @@ def test_json_converter_numpy_types():
         assert 1 is hug.output_format._json_converter(np_type(1))
     for np_type in np_float_types:
         assert .5 == hug.output_format._json_converter(np_type(.5))
-    for np_type in np_str_types:
-        assert 'a' is hug.output_format._json_converter(np_type('a'))
+    for np_type in np_unicode_types:
+        assert "a" == hug.output_format._json_converter(np_type('a'))
+    for np_type in np_bytes_types:
+        assert "a" == hug.output_format._json_converter(np_type('a'))
 
 def test_output_format_with_no_docstring():
     """Ensure it is safe to use formatters with no docstring"""

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -310,9 +310,9 @@ def test_prefix():
 def test_json_converter_numpy_types():
     """Ensure that numpy-specific data types (array, int, float) are properly supported in JSON output."""
     ex_np_array = numpy.array([1, 2, 3, 4, 5])
-    ex_np_int = numpy.int_([5, 4, 3])
+    ex_np_int_array = numpy.int_([5, 4, 3])
     ex_np_float = numpy.float(1.0)
 
     assert [1, 2, 3, 4, 5] == hug.output_format._json_converter(ex_np_array)
-    assert [5, 4, 3] == hug.output_format._json_converter(ex_np_int)
+    assert [5, 4, 3] == hug.output_format._json_converter(ex_np_int_array)
     assert 1.0 == hug.output_format._json_converter(ex_np_float)


### PR DESCRIPTION
E.g. numpy.float does not cover all float types and is platform dependent.

Resolves https://github.com/timothycrosley/hug/issues/668 .
