### PR TITLE
Add `marshmallow` as a test requirement, and fix pytest setup

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -45,6 +45,7 @@ Code Contributors
 - Trevor Bekolay (@tbekolay)
 - Elijah Wilson (@tizz98)
 - Chelsea Dole (@chelseadole)
+- Antti Kaihola (@akaihola)
 
 Documenters
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Ideally, within a virtual environment.
 Changelog
 =========
 
+### 2.4.4 - TBD
+- Fix running tests using `python setup.py test`
+
 ### 2.4.3 [hotfix] - March 17, 2019
 - Fix issue #737 - latest hug release breaks meinheld worker setup
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,9 @@ max-line-length = 120
 
 [metadata]
 license_file = LICENSE
+
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = tests

--- a/setup.py
+++ b/setup.py
@@ -26,27 +26,11 @@ import sys
 from os import path
 
 from setuptools import Extension, setup
-from setuptools.command.test import test as TestCommand
-
-
-class PyTest(TestCommand):
-    extra_kwargs = {'tests_require': ['pytest', 'mock']}
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        sys.exit(pytest.main())
-
 
 MYDIR = path.abspath(os.path.dirname(__file__))
 CYTHON = False
 JYTHON = 'java' in sys.platform
 
-cmdclass = {'test': PyTest}
 ext_modules = []
 
 try:
@@ -109,7 +93,8 @@ setup(
     packages=['hug'],
     requires=['falcon', 'requests'],
     install_requires=['falcon==1.4.1', 'requests'],
-    cmdclass=cmdclass,
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest', 'mock', 'marshmallow'],
     ext_modules=ext_modules,
     python_requires=">=3.4",
     keywords='Web, Python, Python3, Refactoring, REST, Framework, RPC',
@@ -126,6 +111,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries',
         'Topic :: Utilities'
-    ],
-    **PyTest.extra_kwargs
+    ]
 )


### PR DESCRIPTION
Running `python setup.py test` on `develop` would give me an
```
ERROR: file not found: test
```

In this PR, pytest is now integrated according to the recommendations at
https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner

The default test run is also limited to tests under the `tests/`
directory, excluding e.g. `benchmarks/` which would have added a
number of dependencies.