### PR TITLE
Add unit test for `extend_api()` with CLI commands (#744)

### DIFF
--- a/ACKNOWLEDGEMENTS.md
+++ b/ACKNOWLEDGEMENTS.md
@@ -45,6 +45,7 @@ Code Contributors
 - Trevor Bekolay (@tbekolay)
 - Elijah Wilson (@tizz98)
 - Chelsea Dole (@chelseadole)
+- Antti Kaihola (@akaihola)
 
 Documenters
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Ideally, within a virtual environment.
 Changelog
 =========
 
+### 2.4.4 - TBD
+- Add unit test for `extend_api()` with CLI commands
+
 ### 2.4.3 [hotfix] - March 17, 2019
 - Fix issue #737 - latest hug release breaks meinheld worker setup
 

--- a/tests/module_fake_http_and_cli.py
+++ b/tests/module_fake_http_and_cli.py
@@ -1,0 +1,7 @@
+import hug
+
+
+@hug.get()
+@hug.cli()
+def made_up_go():
+    return 'Going!'

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -815,6 +815,19 @@ def test_extending_api_with_same_path_under_different_base_url():
     assert hug.test.get(api, '/api/made_up_hello').data == 'hello'
 
 
+def test_extending_api_with_http_and_cli():
+    """Test to ensure it's possible to extend the current API so both HTTP and CLI APIs are extended"""
+    import tests.module_fake_http_and_cli
+
+    @hug.extend_api(base_url='/api')
+    def extend_with():
+        return (tests.module_fake_http_and_cli, )
+
+    assert hug.test.get(api, '/api/made_up_go').data == 'Going!'
+    assert tests.module_fake_http_and_cli.made_up_go() == 'Going!'
+    assert hug.test.cli(tests.module_fake_http_and_cli.made_up_go) == 'Going!'
+
+
 def test_cli():
     """Test to ensure the CLI wrapper works as intended"""
     @hug.cli('command', '1.0.0', output=str)


### PR DESCRIPTION
Strangely, this test doesn't fail.