### PR TITLE
Added the `--without-cython` option to `setup.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog
 - Add unit test for `extend_api()` with CLI commands
 - Fix running tests using `python setup.py test`
 - Documented the `multiple_files` example
+- Added the `--without-cython` option to `setup.py`
 
 ### 2.4.3 [hotfix] - March 17, 2019
 - Fix issue #737 - latest hug release breaks meinheld worker setup

--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,15 @@ except AttributeError:
     PYPY = False
 
 if not PYPY and not JYTHON:
-    try:
-        from Cython.Distutils import build_ext
-        CYTHON = True
-    except ImportError:
+    if '--without-cython' in sys.argv:
+        sys.argv.remove('--without-cython')
         CYTHON = False
+    else:
+        try:
+            from Cython.Distutils import build_ext
+            CYTHON = True
+        except ImportError:
+            CYTHON = False
 
 if CYTHON:
     def list_modules(dirname):


### PR DESCRIPTION
This way you can choose to do a pure Python installation in your development environment even if you do have Cython installed:

    python setup.py install --without-cython
    python setup.py develop --without-cython
    pip install -e . --install-option="--without-cython"