### PR TITLE
Fix generated API documentation with selectable output type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Ideally, within a virtual environment.
 Changelog
 =========
 
+### 2.4.7 - TBD
+- Fixed API documentation with selectable output types
+
 ### 2.4.6 - March 25, 2019
 - Fixed issue #753 - 404 not found does not respect default output format.
 - Documented the `--without-cython` option in `CONTRIBUTING.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Ideally, within a virtual environment.
 Changelog
 =========
 
-### 2.4.7 - March 27, 2019
+### 2.4.7 - March 28, 2019
 - Fixed API documentation with selectable output types
 
 ### 2.4.6 - March 25, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Ideally, within a virtual environment.
 Changelog
 =========
 
-### 2.4.7 - TBD
+### 2.4.7 - March 27, 2019
 - Fixed API documentation with selectable output types
 
 ### 2.4.6 - March 25, 2019

--- a/hug/api.py
+++ b/hug/api.py
@@ -310,7 +310,7 @@ class HTTPInterfaceAPI(InterfaceAPI):
                 response.data = hug.output_format.json(to_return, indent=4, separators=(',', ': '))
                 response.content_type = 'application/json; charset=utf-8'
             else:
-                response.data = self.output_format(to_return, request, response)
+                response.data = self.output_format(to_return, request=request, response=response)
                 response.content_type = self.output_format.content_type
 
             response.status = falcon.HTTP_NOT_FOUND

--- a/hug/api.py
+++ b/hug/api.py
@@ -310,7 +310,7 @@ class HTTPInterfaceAPI(InterfaceAPI):
                 response.data = hug.output_format.json(to_return, indent=4, separators=(',', ': '))
                 response.content_type = 'application/json; charset=utf-8'
             else:
-                response.data = self.output_format(to_return)
+                response.data = self.output_format(to_return, request, response)
                 response.content_type = self.output_format.content_type
 
             response.status = falcon.HTTP_NOT_FOUND

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -164,7 +164,7 @@ def test_basic_documentation_output_type_accept():
         handler(Request(create_environ(path='v1/doc')), response)
 
     documentation = json.loads(response.data.decode('utf8'))['documentation']
-    assert set(documentation) == {'handlers', 'overview'}
+    assert 'handlers' in documentation and 'overview' in documentation
 
     
 def test_marshmallow_return_type_documentation():

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -20,6 +20,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 """
 import json
+from unittest import mock
 
 import marshmallow
 from falcon import Request
@@ -148,6 +149,22 @@ def test_basic_documentation():
     assert 'versions' in documentation
     assert '/echo' in documentation['handlers']
     assert '/test' not in documentation['handlers']
+
+
+def test_basic_documentation_output_type_accept():
+    """Ensure API documentation works with selectable output types"""
+    accept_output = hug.output_format.accept(
+        {'application/json': hug.output_format.json,
+         'application/pretty-json': hug.output_format.pretty_json},
+        default=hug.output_format.json)
+    with mock.patch.object(api.http, '_output_format', accept_output, create=True):
+        handler = api.http.documentation_404()
+        response = StartResponseMock()
+
+        handler(Request(create_environ(path='v1/doc')), response)
+
+    documentation = json.loads(response.data.decode('utf8'))['documentation']
+    assert set(documentation) == {'handlers', 'overview'}
 
     
 def test_marshmallow_return_type_documentation():


### PR DESCRIPTION
After the fix to #753 ("404 not found does not respect default output format"), API documentation didn't work anymore if using a `hug.output_format.accept()` construct as the default output format.

This patch adds a failing test and a fix for this.

I was confused whether to base this on `master` or `develop`. Let me know if I need to rebase.