### PR TITLE
Fix issue #762 - HTTP errors crash with selectable output types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Ideally, within a virtual environment.
 Changelog
 =========
 
+### 2.4.8 - TBD
+- Fixed issue #762 - HTTP errors crash with selectable output types
+
 ### 2.4.7 - March 28, 2019
 - Fixed API documentation with selectable output types
 

--- a/hug/api.py
+++ b/hug/api.py
@@ -369,7 +369,8 @@ class HTTPInterfaceAPI(InterfaceAPI):
 
         def error_serializer(request, response, error):
             response.content_type = self.output_format.content_type
-            response.body = self.output_format({"errors": {error.title: error.description}})
+            response.body = self.output_format({"errors": {error.title: error.description}},
+                                               request, response)
 
         falcon_api.set_error_serializer(error_serializer)
         return falcon_api


### PR DESCRIPTION
Includes the fix, a test which fails without the fix, and a change log entry.