### PR TITLE
test how falcon encodes query parameters list

### DIFF
--- a/tests/test_input_format.py
+++ b/tests/test_input_format.py
@@ -54,6 +54,10 @@ def test_urlencoded():
     """Ensure that urlencoded input format works as intended"""
     test_data = BytesIO(b"foo=baz&foo=bar&name=John+Doe")
     assert hug.input_format.urlencoded(test_data) == {"name": "John Doe", "foo": ["baz", "bar"]}
+    test_data = BytesIO(b"foo=baz,bar&name=John+Doe")
+    assert hug.input_format.urlencoded(test_data) == {"name": "John Doe", "foo": ["baz", "bar"]}
+    test_data = BytesIO(b"foo=baz,&name=John+Doe")
+    assert hug.input_format.urlencoded(test_data) == {"name": "John Doe", "foo": ["baz"]}
 
 
 def test_multipart():


### PR DESCRIPTION
- Issue 719 was addressed by providing a legal way to format query parameters that represent a list of strings
- The tests added in this PR make it so these legal formats are included in testing