### PR TITLE
Added streaming jsonl format

### DIFF
--- a/documentation/OUTPUT_FORMATS.md
+++ b/documentation/OUTPUT_FORMATS.md
@@ -82,6 +82,7 @@ hug provides a large catalog of built-in output formats, which can be used to bu
  - `hug.output_format.html`: Outputs Hyper Text Markup Language (HTML).
  - `hug.output_format.json_camelcase`: Outputs in the JSON format, but first converts all keys to camelCase to better conform to Javascript coding standards.
  - `hug.output_format.pretty_json`: Outputs in the JSON format, with extra whitespace to improve human readability.
+ - `hug.output_format.json_streaming_lines`: Takes an interable or yield statements and streams it as newline-seperated json objects.
  - `hug.output_format.image(format)`: Outputs an image (of the specified format).
     - There are convenience calls in the form `hug.output_format.{FORMAT}_image for the following image types: 'png', 'jpg', 'bmp', 'eps', 'gif', 'im', 'jpeg', 'msp', 'pcx', 'ppm', 'spider', 'tiff', 'webp', 'xbm',
                'cur', 'dcx', 'fli', 'flc', 'gbr', 'gd', 'ico', 'icns', 'imt', 'iptc', 'naa', 'mcidas', 'mpo', 'pcd',

--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -175,6 +175,16 @@ def json(content, request=None, response=None, ensure_ascii=False, **kwargs):
         content, default=_json_converter, ensure_ascii=ensure_ascii, **kwargs
     ).encode("utf8")
 
+@content_type("application/jsonl; charset=utf-8")
+def json_streaming_lines(data, request=None, response=None,**kwargs):
+    """Stream a json response using the jsonl format, where each unique json-object is
+    seperated by a newline
+    """
+    now = str(datetime.utcnow())
+    response.append_header('Content-Disposition',
+                           (f'attachment; filename="{now}.jsonl"'))
+    response.stream = (json(i,indent=None,**kwargs)+b"\n" for i in data)
+    return
 
 def on_valid(valid_content_type, on_invalid=json):
     """Renders as the specified content type only if no errors are found in the provided data object"""


### PR DESCRIPTION
Right now there doesn't seem to be any good way to stream chunks of content out of hug. That would be useful for all kinds of things, things like chat servers, event subscription, or just dealing with really large chunks of data.

This would enable a very simple "long-polling" style of streaming, as opposed to something more complex like websockets. Some deployments might be vulnerable to slowloris style denial-of-service attacks when combined with long-polling, but this is something like the third time I've written this for a project so I figure it's probably worth including. the ASGI servers shouldn't have any problems with it.