### PR TITLE
Fix CLI help message broken when using subcommands (Issue/875)

### DIFF
--- a/hug/api.py
+++ b/hug/api.py
@@ -470,9 +470,10 @@ class CLIInterfaceAPI(InterfaceAPI):
 
     def __str__(self):
         output = "{0}\n\nAvailable Commands:\n\n".format(self.api.doc or self.api.name)
+        max_length = max((len(command_name) for command_name in self.commands))
         for command_name, command in self.commands.items():
             command_string = " - {}{}".format(
-                command_name, ": " + str(command).split('\n')[0] if str(command) else ""
+                command_name.ljust(max_length+3), str(command).split('\n')[0] if str(command) else ""
             )
             output += command_string[:77] + "..." if len(command_string) > 80 else command_string
             output += "\n"

--- a/hug/api.py
+++ b/hug/api.py
@@ -472,7 +472,7 @@ class CLIInterfaceAPI(InterfaceAPI):
         output = "{0}\n\nAvailable Commands:\n\n".format(self.api.doc or self.api.name)
         for command_name, command in self.commands.items():
             command_string = " - {}{}".format(
-                command_name, ": " + str(command).replace("\n", " ") if str(command) else ""
+                command_name, ": " + str(command).split('\n')[0] if str(command) else ""
             )
             output += command_string[:77] + "..." if len(command_string) > 80 else command_string
             output += "\n"


### PR DESCRIPTION
Fixes [issue 875](https://github.com/hugapi/hug/issues/875) concerning help message format when using subcommands.