### PR TITLE
don't set 'Access-Control-Allow-Origin: None'

### DIFF
--- a/hug/middleware.py
+++ b/hug/middleware.py
@@ -181,7 +181,7 @@ class CORSMiddleware(object):
         response.set_header("Access-Control-Allow-Credentials", str(self.allow_credentials).lower())
 
         origin = request.get_header("ORIGIN")
-        if origin and (origin in self.allow_origins) or ("*" in self.allow_origins):
+        if origin and ((origin in self.allow_origins) or ("*" in self.allow_origins)):
             response.set_header("Access-Control-Allow-Origin", origin)
 
         if request.method == "OPTIONS":  # check if we are handling a preflight request


### PR DESCRIPTION
When there is no origin with `'*'` allowed, it is returning 'Access-Control-Allow-Origin: None'
The bug was just a misunderstanding of how python evaluates `if None and False or True` -> it evaluates to `True`, not `None`
Note: If you use the default `CORSMiddleware`, it has `allow_origins` of `['*']`.
So when it checks to see if it should set the header on response, it's deciding to return the header, but `origin` is `None`.
So it ends up returning a funny looking header.
It could alternatively set the header to `origin or '*'` which is maybe more descriptive, but not necessary.