### PR TITLE
docs: Fix a few typos

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ Q: *Can I use Hug with a web framework -- Django for example?*
 
 A: You can use Hug alongside Django or the web framework of your choice, but it does have drawbacks. You would need to run hug on a separate, hug-exclusive server. You can also [mount Hug as a WSGI app](https://pythonhosted.org/django-wsgi/embedded-apps.html), embedded within your normal Django app.
 
-Q: *Is Hug compatabile with Python 2?*
+Q: *Is Hug compatible with Python 2?*
 
 A: Python 2 is not supported by Hug. However, if you need to account for backwards compatability, there are workarounds. For example, you can wrap the decorators:
 

--- a/documentation/OUTPUT_FORMATS.md
+++ b/documentation/OUTPUT_FORMATS.md
@@ -43,11 +43,11 @@ Finally, an output format may be a collection of different output formats that g
     suffix_output = hug.output_format.suffix({'.js': hug.output_format.json,
                                               '.html': hug.output_format.html})
 
-    @hug.get(('my_endpoint.js', 'my_endoint.html'), output=suffix_output)
+    @hug.get(('my_endpoint.js', 'my_endpoint.html'), output=suffix_output)
     def my_endpoint():
         return ''
 
-In this case, if the endpoint is accessed via my_endpoint.js, the output type will be JSON; however if it's accessed via my_endoint.html, the output type will be HTML.
+In this case, if the endpoint is accessed via my_endpoint.js, the output type will be JSON; however if it's accessed via my_endpoint.html, the output type will be HTML.
 
 You can also change the default output format globally for all APIs with either:
 

--- a/hug/__init__.py
+++ b/hug/__init__.py
@@ -5,7 +5,7 @@ simple as possible, but no simpler.
 
 Hug's Design Objectives:
 
-- Make developing a Python driven API as succint as a written definition.
+- Make developing a Python driven API as succinct as a written definition.
 - The framework should encourage code that self-documents.
 - It should be fast. Never should a developer feel the need to look somewhere else for performance reasons.
 - Writing tests for APIs written on-top of Hug should be easy and intuitive.

--- a/hug/route.py
+++ b/hug/route.py
@@ -122,7 +122,7 @@ class API(object):
         return http(*args, **kwargs)
 
     def urls(self, *args, **kwargs):
-        """DEPRECATED: for backwords compatibility with < hug 2.2.0. `API.http` should be used instead.
+        """DEPRECATED: for backwards compatibility with < hug 2.2.0. `API.http` should be used instead.
 
            Starts the process of building a new URL HTTP route linked to this API instance
         """
@@ -240,5 +240,5 @@ put_post.__doc__ = "Exposes a Python method externally under both the HTTP POST 
 
 object = Object()
 
-# DEPRECATED: for backwords compatibility with hug 1.x.x
+# DEPRECATED: for backwards compatibility with hug 1.x.x
 call = http

--- a/hug/store.py
+++ b/hug/store.py
@@ -1,6 +1,6 @@
 """hug/store.py.
 
-A collecton of native stores which can be used with, among others, the session middleware.
+A collection of native stores which can be used with, among others, the session middleware.
 
 Copyright (C) 2016 Timothy Edmund Crosley
 

--- a/hug/types.py
+++ b/hug/types.py
@@ -342,7 +342,7 @@ class OneOf(Type):
 
 
 class Mapping(OneOf):
-    """Ensures the value is one of an acceptable set of values mapping those values to a Python equivelent"""
+    """Ensures the value is one of an acceptable set of values mapping those values to a Python equivalent"""
 
     __slots__ = ("value_map",)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -83,7 +83,7 @@ def test_greater_than():
 
 
 def test_multiple():
-    """Tests that hug's multile type correctly forces values to come back as lists, but not lists of lists"""
+    """Tests that hug's multiple type correctly forces values to come back as lists, but not lists of lists"""
     assert hug.types.multiple("value") == ["value"]
     assert hug.types.multiple(["value1", "value2"]) == ["value1", "value2"]
 


### PR DESCRIPTION
There are small typos in:
- FAQ.md
- documentation/OUTPUT_FORMATS.md
- hug/__init__.py
- hug/route.py
- hug/store.py
- hug/types.py
- tests/test_types.py

Fixes:
- Should read `backwards` rather than `backwords`.
- Should read `succinct` rather than `succint`.
- Should read `multiple` rather than `multile`.
- Should read `equivalent` rather than `equivelent`.
- Should read `endpoint` rather than `endoint`.
- Should read `compatible` rather than `compatabile`.
- Should read `collection` rather than `collecton`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md