### PR TITLE
adapt for numpy 2.0

### DIFF
--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -142,7 +142,7 @@ if numpy:
     def numpy_listable(item):
         return item.tolist()
 
-    @json_convert(str, numpy.unicode_)
+    @json_convert(str, numpy.str_)
     def numpy_stringable(item):
         return str(item)
 

--- a/requirements/build_common.txt
+++ b/requirements/build_common.txt
@@ -6,4 +6,4 @@ python-coveralls==2.9.2
 wheel==0.33.4
 PyJWT==1.7.1
 pytest-xdist==1.29.0
-numpy<1.16
+numpy==2.0.0

--- a/requirements/build_windows.txt
+++ b/requirements/build_windows.txt
@@ -5,4 +5,4 @@ marshmallow==2.18.1
 pytest==4.6.3
 wheel==0.33.4
 pytest-xdist==1.29.0
-numpy==1.15.4
+numpy==2.0.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -12,5 +12,5 @@ wheel
 pytest-xdist==1.29.0
 marshmallow==2.18.1
 ujson==1.35
-numpy<1.16
+numpy==2.0.0
 


### PR DESCRIPTION
`np.unicode_` has been removed in Numpy 2.0 

https://github.com/hugapi/hug/blob/e4a3fa40f98487a67351311d0da659a6c9ce88a6/hug/output_format.py#L145-L147


```
   import hug
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/hug/__init__.py", line 36, in <module>
    from hug import (
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/hug/output_format.py", line 145, in <module>
    @json_convert(str, numpy.unicode_)
                       ^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/numpy/__init__.py", line 397, in __getattr__
    raise AttributeError(
AttributeError: `np.unicode_` was removed in the NumPy 2.0 release. Use `np.str_` instead.
```