### PR TITLE
Basic fixes for python > 3.12

### DIFF
--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -142,7 +142,7 @@ if numpy:
     def numpy_listable(item):
         return item.tolist()
 
-    @json_convert(str, numpy.unicode_)
+    @json_convert(str, numpy.str_)
     def numpy_stringable(item):
         return str(item)
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ with open("README.md", encoding="utf-8") as f:  # Loads in the README for PyPI
 
 setup(
     name="hug",
-    version="2.6.1",
+    version="2.6.2",
     description="A Python framework that makes developing APIs "
     "as simple as possible, but no simpler.",
     long_description=long_description,
@@ -96,7 +96,7 @@ setup(
     entry_points={"console_scripts": ["hug = hug:development_runner.hug.interface.cli"]},
     packages=["hug"],
     requires=["falcon", "requests"],
-    install_requires=["falcon==2.0.0", "requests"],
+    install_requires=["falcon", "requests"],
     tests_require=["pytest", "marshmallow"],
     ext_modules=ext_modules,
     cmdclass=cmdclass,

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -405,7 +405,7 @@ def test_json_converter_numpy_types():
         numpy.single,
         numpy.longfloat,
     ]
-    np_unicode_types = [numpy.unicode_]
+    np_unicode_types = [numpy.str_]
     np_bytes_types = [numpy.bytes_]
 
     for np_type in np_bool_types:


### PR DESCRIPTION
I came across this project when trying to run [portray](https://timothycrosley.github.io/portray/) with python3.12.

Using these two commits, I am able to run the example from the readme:

```
import hug

@hug.get()
def hello():
    '''says hello'''
    return "hello"
```

I assume, that other things are broken, too, but I don't know how to verify.