### PR TITLE
Support Marshmallow 3

### DIFF
--- a/hug/types.py
+++ b/hug/types.py
@@ -668,7 +668,7 @@ class MarshmallowInputSchema(Type):
     def __doc__(self):
         return self.schema.__doc__ or self.schema.__class__.__name__
 
-    def __call__(self, value, context):
+    def __call__(self, value, context=None):
         self.schema.context = context
         # In marshmallow 2 schemas return tuple (`data`, `errors`) upon loading. They might also raise on invalid data
         # if configured so, but will still return a tuple.

--- a/hug/types.py
+++ b/hug/types.py
@@ -686,6 +686,8 @@ class MarshmallowInputSchema(Type):
                 )
             except ValidationError as e:
                 errors = e.messages
+            except ValueError as e:
+                errors = [str(e)]
 
         if errors:
             raise InvalidTypeData(
@@ -727,6 +729,8 @@ class MarshmallowReturnSchema(Type):
                 value = self.schema.dump(value)
             except ValidationError as e:
                 errors = e.messages
+            except ValueError as e:
+                errors = [str(e)]
 
         if errors:
             raise InvalidTypeData(

--- a/tests/test_context_factory.py
+++ b/tests/test_context_factory.py
@@ -128,7 +128,7 @@ class TestContextFactoryLocal(object):
             name = fields.Str()
 
             @post_dump()
-            def check_context(self, data):
+            def check_context(self, data, **kwargs):
                 assert self.context["test"] == "context"
                 self.context["test_number"] += 1
 
@@ -304,7 +304,7 @@ class TestContextFactoryCLI(object):
             name = fields.Str()
 
             @post_dump()
-            def check_context(self, data):
+            def check_context(self, data, **kwargs):
                 assert self.context["test"] == "context"
                 self.context["test_number"] += 1
 
@@ -479,7 +479,7 @@ class TestContextFactoryHTTP(object):
             name = fields.Str()
 
             @post_dump()
-            def check_context(self, data):
+            def check_context(self, data, **kwargs):
                 assert self.context["test"] == "context"
                 self.context["test_number"] += 1
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -464,7 +464,7 @@ def test_marshmallow_custom_context():
         name = fields.String()
 
         @validates_schema
-        def check_context(self, data):
+        def check_context(self, data, **kwargs):
             assert self.context == custom_context
             self.context["marshmallow"] += 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=py{35,36,37,38,py3}-marshmallow{2,3}, cython-marshmallow{2,3}
 deps=
     -rrequirements/build_common.txt
     marshmallow2: marshmallow <3.0
-    marshmallow3: marshmallow==3.0.0rc6
+    marshmallow3: marshmallow>3.0
 
 whitelist_externals=flake8
 commands=py.test --durations 3 --cov-report html --cov hug -n auto tests
@@ -13,7 +13,7 @@ commands=py.test --durations 3 --cov-report html --cov hug -n auto tests
 [testenv:py37-black]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow==3.0.0rc6
+    marshmallow>3.0
 
 whitelist_externals=flake8
 commands=black --check --verbose -l 100 hug
@@ -21,7 +21,7 @@ commands=black --check --verbose -l 100 hug
 [testenv:py37-vulture]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow==3.0.0rc6
+    marshmallow>3.0
 
 whitelist_externals=flake8
 commands=vulture hug --min-confidence 100 --ignore-names req_succeeded
@@ -30,7 +30,7 @@ commands=vulture hug --min-confidence 100 --ignore-names req_succeeded
 [testenv:py37-flake8]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow==3.0.0rc6
+    marshmallow>3.0
 
 whitelist_externals=flake8
 commands=flake8 hug
@@ -38,7 +38,7 @@ commands=flake8 hug
 [testenv:py37-bandit]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow==3.0.0rc6
+    marshmallow>3.0
 
 whitelist_externals=flake8
 commands=bandit -r hug/ -ll
@@ -46,7 +46,7 @@ commands=bandit -r hug/ -ll
 [testenv:py37-isort]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow==3.0.0rc6
+    marshmallow>3.0
 
 whitelist_externals=flake8
 commands=isort -c --diff --recursive hug
@@ -54,7 +54,7 @@ commands=isort -c --diff --recursive hug
 [testenv:py37-safety]
 deps=
     -rrequirements/build_style_tools.txt
-    marshmallow==3.0.0rc6
+    marshmallow>3.0
 
 whitelist_externals=flake8
 commands=safety check -i 36810


### PR DESCRIPTION
I'm unsure about 3d3591f, but the rest seems pretty straightforward:

1. Take kwargs in post-processors, as marshmallow expects. They've added new named arguments, over time.
2. Handle ValueError in validation.
3. Set a default value for `context` in MarshmallowInputSchema. This is the bit I'm unsure of.
4. Bump marshmallow deps in tox.

Fixes: #859