### PR TITLE
NumPy 2.1 support: Update numpy types

### DIFF
--- a/hug/output_format.py
+++ b/hug/output_format.py
@@ -142,7 +142,7 @@ if numpy:
     def numpy_listable(item):
         return item.tolist()
 
-    @json_convert(str, numpy.unicode_)
+    @json_convert(str, numpy.str_)
     def numpy_stringable(item):
         return str(item)
 

--- a/requirements/build_common.txt
+++ b/requirements/build_common.txt
@@ -6,4 +6,4 @@ python-coveralls==2.9.2
 wheel==0.33.4
 PyJWT==1.7.1
 pytest-xdist==1.29.0
-numpy<1.16
+numpy<2.2

--- a/requirements/build_windows.txt
+++ b/requirements/build_windows.txt
@@ -5,4 +5,4 @@ marshmallow==2.18.1
 pytest==4.6.3
 wheel==0.33.4
 pytest-xdist==1.29.0
-numpy==1.15.4
+numpy<2.2

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -12,5 +12,4 @@ wheel
 pytest-xdist==1.29.0
 marshmallow==2.18.1
 ujson==1.35
-numpy<1.16
-
+numpy<2.2

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -375,7 +375,7 @@ def test_json_converter_numpy_types():
 
     # Some type names are merely shorthands.
     # The following shorthands for built-in types are excluded: numpy.bool, numpy.int, numpy.float.
-    np_bool_types = [numpy.bool_, numpy.bool8]
+    np_bool_types = [numpy.bool_, numpy.bool_]
     np_int_types = [
         numpy.int_,
         numpy.byte,
@@ -398,14 +398,13 @@ def test_json_converter_numpy_types():
         numpy.ushort,
     ]
     np_float_types = [
-        numpy.float_,
         numpy.float32,
         numpy.float64,
         numpy.half,
         numpy.single,
-        numpy.longfloat,
+        numpy.longdouble,
     ]
-    np_unicode_types = [numpy.unicode_]
+    np_unicode_types = [numpy.str_]
     np_bytes_types = [numpy.bytes_]
 
     for np_type in np_bool_types:


### PR DESCRIPTION
`bool8`, `float_`, and `longfloat` were removed in NumPy 2.1